### PR TITLE
Implement basic failover for reading blocks

### DIFF
--- a/filereader.go
+++ b/filereader.go
@@ -242,10 +242,7 @@ func (f *FileReader) getNewBlockReader() error {
 		end := start + block.GetB().GetNumBytes()
 
 		if start <= off && off < end {
-			br, err := rpc.NewBlockReader(block, off-start)
-			if err != nil {
-				return err
-			}
+			br := rpc.NewBlockReader(block, off-start)
 
 			f.currentBlockReader = br
 			return nil

--- a/rpc/blockreader.go
+++ b/rpc/blockreader.go
@@ -1,118 +1,96 @@
 package rpc
 
 import (
-	"bufio"
-	"bytes"
-	"code.google.com/p/goprotobuf/proto"
-	"encoding/binary"
-	"errors"
 	"fmt"
 	hdfs "github.com/colinmarc/hdfs/protocol/hadoop_hdfs"
-	"hash/crc32"
 	"io"
-	"io/ioutil"
-	"math"
-	"net"
+	"time"
 )
 
-const (
-	dataTransferVersion = 0x1c
-	readBlockOp         = 0x51
-)
+// a global map of address -> last failure
+var datanodeFailures = make(map[string]time.Time)
 
-// TODO: datanode blacklisting
-
-// BlockReader implements io.ReaderCloser for reading a single block from HDFS,
-// abstracting over reading from multiple datanodes.
+// BlockReader implements io.ReadCloser, for reading a block. It abstracts over
+// reading from multiple datanodes, in order to be robust to failures.
 type BlockReader struct {
+	block *hdfs.LocatedBlockProto
+
+	datanodes       []string
+	lastError       error
+
+	stream *blockStream
+	offset uint64
 	closed bool
-	conn   net.Conn
-	reader *bufio.Reader
-
-	block       *hdfs.LocatedBlockProto
-	checksumTab *crc32.Table
-
-	offset    uint64
-	chunkSize uint32
-	packet    openPacket
-	buf       bytes.Buffer
-}
-
-type openPacket struct {
-	numChunks     int
-	nextChunk     int
-	checksumBytes []byte
-	blockOffset   uint64
-	packetOffset  uint64
-	length        uint64
-	last          bool
 }
 
 // NewBlockReader returns a new BlockReader, given the block information and
-// security token from the namenode.
-func NewBlockReader(block *hdfs.LocatedBlockProto, offset uint64) (*BlockReader, error) {
-	br := &BlockReader{
-		block:  block,
-		offset: offset,
+// security token from the namenode. It will connect (lazily) to one of the
+// provided datanode locations based on which datanodes have seen failures.
+func NewBlockReader(block *hdfs.LocatedBlockProto, offset uint64) *BlockReader {
+	locs := block.GetLocs()
+	datanodes := make([]string, len(locs))
+	for i, loc := range locs {
+		dn := loc.GetId()
+		datanodes[i] = fmt.Sprintf("%s:%d", dn.GetIpAddr(), dn.GetXferPort())
 	}
 
-	// TODO check multiple datanodes
-	datanode := br.block.GetLocs()[0].GetId()
-	address := fmt.Sprintf("%s:%d", datanode.GetIpAddr(), datanode.GetXferPort())
-	err := br.connect(address)
-	if err != nil {
-		return nil, err
+	return &BlockReader{
+		block:     block,
+		datanodes: datanodes,
+		offset:    offset,
 	}
-
-	return br, nil
 }
 
-func (br *BlockReader) connect(datanode string) error {
-	conn, err := net.DialTimeout("tcp", datanode, connectionTimeout)
+// connectNext pops a datanode from the list based on previous failures, and
+// connects to it.
+func (br *BlockReader) connectNext() error {
+	address := br.nextDatanode()
+	stream, err := newBlockStream(address, br.block, br.offset)
 	if err != nil {
 		return err
 	}
 
-	br.conn = conn
-	err = br.writeBlockReadRequest()
-	if err != nil {
-		return err
-	}
-
-	br.reader = bufio.NewReader(br.conn)
-	resp, err := br.readBlockReadResponse()
-	if err != nil {
-		return err
-	}
-
-	checksumInfo := resp.GetReadOpChecksumInfo().GetChecksum()
-	checksumType := checksumInfo.GetType()
-	if checksumType == hdfs.ChecksumTypeProto_CHECKSUM_CRC32 {
-		br.checksumTab = crc32.IEEETable
-	} else if checksumType == hdfs.ChecksumTypeProto_CHECKSUM_CRC32C {
-		br.checksumTab = crc32.MakeTable(crc32.Castagnoli)
-	} else {
-		return fmt.Errorf("Unsupported checksum type: %s", checksumType)
-	}
-
-	br.chunkSize = checksumInfo.GetBytesPerChecksum()
-	br.startNewPacket()
-
-	// The read will start aligned to a chunk boundary, so we need to seek forward
-	// to the requested offset.
-	amountToDiscard := br.offset - br.packet.blockOffset
-	if amountToDiscard > 0 {
-		io.CopyN(ioutil.Discard, br, int64(amountToDiscard))
-	}
-
+	br.stream = stream
 	return nil
 }
 
-func (br *BlockReader) Close() {
-	br.conn.Close()
-	br.closed = true
+func (br *BlockReader) nextDatanode() string {
+	var picked int = -1
+	var oldestFailure time.Time
+
+	for i, address := range br.datanodes {
+		failedAt, hasFailed := datanodeFailures[address]
+
+		if !hasFailed {
+			picked = i
+			break
+		} else if oldestFailure.IsZero() || failedAt.Before(oldestFailure) {
+			picked = i
+			oldestFailure = failedAt
+		}
+	}
+
+	address := br.datanodes[picked]
+	br.datanodes = append(br.datanodes[:picked], br.datanodes[picked+1:]...)
+
+	return address
 }
 
+func (br *BlockReader) recordFailure(err error) {
+	datanodeFailures[br.stream.address] = time.Now()
+	br.lastError = err
+	br.stream = nil
+}
+
+// Read implements io.Reader.
+//
+// In the case that a failure (such as a disconnect) occurs while reading, the
+// BlockReader will failover to another datanode and continue reading
+// transparently. In the case that all the datanodes fail, the error
+// from the most recent attempt will be returned.
+//
+// Any datanode failures are recorded in a global cache, so subsequent reads,
+// even reads for different blocks, will prioritize them lower.
 func (br *BlockReader) Read(b []byte) (int, error) {
 	if br.closed {
 		return 0, io.ErrClosedPipe
@@ -121,212 +99,40 @@ func (br *BlockReader) Read(b []byte) (int, error) {
 		return 0, io.EOF
 	}
 
-	// first, read any leftover data from buf
-	if br.buf.Len() > 0 {
-		n, _ := br.buf.Read(b)
-		return n, nil
-	}
-
-	if br.packet.nextChunk >= br.packet.numChunks {
-		if br.packet.last {
-			return 0, io.EOF
-		}
-
-		br.startNewPacket()
-	}
-
-	// then, read until we fill up b or we reach the end of the packet
-	readOffset := 0
-	for br.packet.nextChunk < br.packet.numChunks {
-		chOff := 4 * br.packet.nextChunk
-		checksum := br.packet.checksumBytes[chOff : chOff+4]
-
-		remaining := br.packet.length - br.packet.packetOffset
-		chunkLength := int64(math.Min(float64(br.chunkSize), float64(remaining)))
-
-		chunkReader := io.LimitReader(br.reader, int64(chunkLength))
-		chunkBytes := b[readOffset:]
-		bytesToRead := int(math.Min(float64(len(chunkBytes)), float64(chunkLength)))
-		n, err := io.ReadAtLeast(chunkReader, chunkBytes, bytesToRead)
-
-		readOffset += n
-		br.packet.packetOffset += uint64(n)
-		br.packet.nextChunk++
-
-		if err != nil {
-			br.Close()
-			return readOffset, err
-		}
-
-		crc := crc32.Checksum(chunkBytes[:n], br.checksumTab)
-
-		if int64(n) < chunkLength {
-			// save any leftovers
-			br.buf.Reset()
-			leftover, err := br.buf.ReadFrom(chunkReader)
+	// the main retry loop
+	for br.stream != nil || len(br.datanodes) > 0 {
+		if br.stream == nil {
+			err := br.connectNext()
 			if err != nil {
-				return readOffset, err
+				br.recordFailure(err)
+				continue
 			}
-
-			br.packet.packetOffset += uint64(leftover)
-
-			// update the checksum with the leftovers
-			crc = crc32.Update(crc, br.checksumTab, br.buf.Bytes())
 		}
 
-		if crc != binary.BigEndian.Uint32(checksum) {
-			return readOffset, errors.New("Invalid checksum from the datanode!")
+		n, err := br.stream.Read(b)
+		if err != nil && err != io.EOF {
+			br.recordFailure(err)
+			if n > 0 {
+				br.offset += uint64(n)
+				return n, nil
+			} else {
+				continue
+			}
 		}
 
-		if readOffset == len(b) {
-			break
-		}
+		return n, err
 	}
 
-	return readOffset, nil
+	return 0, br.lastError
 }
 
-// A read request to a datanode:
-// +-----------------------------------------------------------+
-// |  Data Transfer Protocol Version, int16                    |
-// +-----------------------------------------------------------+
-// |  Op code, 1 byte (READ_BLOCK = 0x51)                      |
-// +-----------------------------------------------------------+
-// |  varint length + OpReadBlockProto                         |
-// +-----------------------------------------------------------+
-func (br *BlockReader) writeBlockReadRequest() error {
-	header := []byte{0x00, dataTransferVersion, readBlockOp}
+// Close implements io.Closer.
+func (br *BlockReader) Close() error {
+	br.closed = true
 
-	// TODO offset/length?
-	needed := (br.block.GetB().GetNumBytes() - br.offset)
-	op := newReadBlockOp(br.block, br.offset, needed)
-	opBytes, err := makeDelimitedMsg(op)
-	if err != nil {
-		return err
-	}
-
-	req := append(header, opBytes...)
-	_, err = br.conn.Write(req)
-	if err != nil {
-		return err
+	if br.stream != nil {
+		br.stream.Close()
 	}
 
 	return nil
-}
-
-// The initial response from the datanode:
-// +-----------------------------------------------------------+
-// |  varint length + BlockOpResponseProto                     |
-// +-----------------------------------------------------------+
-func (br *BlockReader) readBlockReadResponse() (*hdfs.BlockOpResponseProto, error) {
-	respLength, err := binary.ReadUvarint(br.reader)
-	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-
-		return nil, err
-	}
-
-	respBytes := make([]byte, respLength)
-	_, err = io.ReadFull(br.reader, respBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	resp := &hdfs.BlockOpResponseProto{}
-	err = proto.Unmarshal(respBytes, resp)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
-}
-
-// A packet from the datanode:
-// +-----------------------------------------------------------+
-// |  uint32 length of the packet                              |
-// +-----------------------------------------------------------+
-// |  size of the PacketHeaderProto, uint16                    |
-// +-----------------------------------------------------------+
-// |  PacketHeaderProto                                        |
-// +-----------------------------------------------------------+
-// |  N checksums, 4 bytes each                                |
-// +-----------------------------------------------------------+
-// |  N chunks of payload data                                 |
-// +-----------------------------------------------------------+
-func (br *BlockReader) startNewPacket() error {
-	header, err := br.readPacketHeader()
-	if err != nil {
-		return err
-	}
-
-	blockOffset := uint64(header.GetOffsetInBlock())
-	dataLength := uint64(header.GetDataLen())
-	numChunks := int(math.Ceil(float64(dataLength) / float64(br.chunkSize)))
-
-	// TODO don't assume checksum size is 4
-	br.packet = openPacket{
-		numChunks:     numChunks,
-		nextChunk:     0,
-		checksumBytes: make([]byte, numChunks*4),
-		blockOffset:   blockOffset,
-		packetOffset:  0,
-		length:        dataLength,
-		last:          header.GetLastPacketInBlock(),
-	}
-
-	_, err = io.ReadFull(br.reader, br.packet.checksumBytes)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (br *BlockReader) readPacketHeader() (*hdfs.PacketHeaderProto, error) {
-	var packetLength uint32
-	err := binary.Read(br.reader, binary.BigEndian, &packetLength)
-	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-
-		return nil, err
-	}
-
-	var packetHeaderLength uint16
-	err = binary.Read(br.reader, binary.BigEndian, &packetHeaderLength)
-	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-
-		return nil, err
-	}
-
-	packetHeaderBytes := make([]byte, packetHeaderLength)
-	_, err = io.ReadFull(br.reader, packetHeaderBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	packetHeader := &hdfs.PacketHeaderProto{}
-	err = proto.Unmarshal(packetHeaderBytes, packetHeader)
-
-	return packetHeader, nil
-}
-
-func newReadBlockOp(block *hdfs.LocatedBlockProto, offset, length uint64) *hdfs.OpReadBlockProto {
-	return &hdfs.OpReadBlockProto{
-		Header: &hdfs.ClientOperationHeaderProto{
-			BaseHeader: &hdfs.BaseHeaderProto{
-				Block: block.GetB(),
-				Token: block.GetBlockToken(),
-			},
-			ClientName: proto.String(ClientName),
-		},
-		Offset: proto.Uint64(offset),
-		Len:    proto.Uint64(length),
-	}
 }

--- a/rpc/blockreader_test.go
+++ b/rpc/blockreader_test.go
@@ -1,0 +1,114 @@
+package rpc
+
+import (
+	"code.google.com/p/goprotobuf/proto"
+	"testing"
+	"testing/iotest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	hdfs "github.com/colinmarc/hdfs/protocol/hadoop_hdfs"
+	"os"
+	"os/user"
+	"bufio"
+	"io"
+	"io/ioutil"
+	"hash/crc32"
+	"time"
+)
+
+func getNamenode(t *testing.T) *NamenodeConnection {
+	nn := os.Getenv("HADOOP_NAMENODE")
+	if nn == "" {
+		t.Fatal("HADOOP_NAMENODE not set")
+	}
+
+	currentUser, _ := user.Current()
+	conn, err := NewNamenodeConnection(nn, currentUser.Username)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return conn
+}
+
+func setupFailover(t *testing.T) *BlockReader {
+	namenode := getNamenode(t)
+
+	req := &hdfs.GetBlockLocationsRequestProto{
+		Src:    proto.String("/_test/mobydick.txt"),
+		Offset: proto.Uint64(0),
+		Length: proto.Uint64(1257276),
+	}
+	resp := &hdfs.GetBlockLocationsResponseProto{}
+
+	err := namenode.Execute("getBlockLocations", req, resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add a duplicate location to failover to
+	block := resp.GetLocations().GetBlocks()[0]
+	block.Locs = append(block.GetLocs(), block.GetLocs()...)
+
+	br := NewBlockReader(block, 0)
+	err = br.connectNext()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return br
+}
+
+func TestPicksFirstDatanode(t *testing.T) {
+	br := setupFailover(t)
+	br.datanodes = []string{"foo:6000", "bar:6000"}
+	assert.Equal(t, br.nextDatanode(), "foo:6000")
+}
+
+func TestPicksDatanodesWithoutFailures(t *testing.T) {
+	br := setupFailover(t)
+	br.datanodes = []string{"foo:6000", "foo:7000", "bar:6000"}
+	datanodeFailures["foo:6000"] = time.Now()
+
+	assert.Equal(t, br.nextDatanode(), "foo:7000")
+}
+
+func TestPicksDatanodesWithOldestFailures(t *testing.T) {
+	br := setupFailover(t)
+	br.datanodes = []string{"foo:6000", "bar:6000"}
+	datanodeFailures["foo:6000"] = time.Now().Add(-10 * time.Minute)
+	datanodeFailures["bar:6000"] = time.Now()
+
+	assert.Equal(t, br.nextDatanode(), "foo:6000")
+}
+
+func TestFailsOver(t *testing.T) {
+	br := setupFailover(t)
+	dn := br.datanodes[0]
+	br.stream.reader = bufio.NewReaderSize(iotest.TimeoutReader(br.stream.reader), 0)
+
+	hash := crc32.NewIEEE()
+	n, err := io.Copy(hash, br)
+	require.Nil(t, err)
+	assert.Equal(t, 1048576, n)
+	assert.Equal(t, 0x2ac4f588, hash.Sum32())
+	assert.Equal(t, 0, len(br.datanodes))
+
+	_, exist := datanodeFailures[dn]
+	assert.True(t, exist)
+}
+
+func TestFailsOverAndThenDies(t *testing.T) {
+	br := setupFailover(t)
+
+	br.stream.reader = bufio.NewReaderSize(iotest.TimeoutReader(br.stream.reader), 0)
+
+	_, err := io.CopyN(ioutil.Discard, br, 10000)
+	require.Nil(t, err)
+	assert.Equal(t, 0, len(br.datanodes))
+
+	br.stream.reader = bufio.NewReaderSize(iotest.TimeoutReader(br.stream.reader), 0)
+	_, err = io.Copy(ioutil.Discard, br)
+	assert.Equal(t, iotest.ErrTimeout, err)
+}
+

--- a/rpc/blockstream.go
+++ b/rpc/blockstream.go
@@ -1,0 +1,324 @@
+package rpc
+
+import (
+	"bufio"
+	"bytes"
+	"code.google.com/p/goprotobuf/proto"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	hdfs "github.com/colinmarc/hdfs/protocol/hadoop_hdfs"
+	"hash/crc32"
+	"io"
+	"io/ioutil"
+	"math"
+	"net"
+)
+
+const (
+	dataTransferVersion = 0x1c
+	readBlockOp         = 0x51
+)
+
+// blockStream implements io.ReaderCloser for reading a single block from HDFS,
+// from a single datanode.
+type blockStream struct {
+	address string
+	block       *hdfs.LocatedBlockProto
+
+	closed bool
+	conn   net.Conn
+	reader *bufio.Reader
+	checksumTab *crc32.Table
+
+	startOffset uint64
+	chunkSize   uint32
+	packet      openPacket
+	buf         bytes.Buffer
+}
+
+type openPacket struct {
+	numChunks     int
+	nextChunk     int
+	checksumBytes []byte
+	blockOffset   uint64
+	packetOffset  uint64
+	length        uint64
+	last          bool
+}
+
+// newBlockStream returns a new connected blockStream.
+func newBlockStream(address string, block *hdfs.LocatedBlockProto, offset uint64) (*blockStream, error) {
+	s := &blockStream{
+		address: address,
+		block:       block,
+		startOffset: offset,
+	}
+
+	err := s.connect()
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (s *blockStream) connect() error {
+	conn, err := net.DialTimeout("tcp", s.address, connectionTimeout)
+	if err != nil {
+		return err
+	}
+
+	s.conn = conn
+	err = s.writeBlockReadRequest()
+	if err != nil {
+		return err
+	}
+
+	s.reader = bufio.NewReader(s.conn)
+	resp, err := s.readBlockReadResponse()
+	if err != nil {
+		return err
+	}
+
+	checksumInfo := resp.GetReadOpChecksumInfo().GetChecksum()
+	checksumType := checksumInfo.GetType()
+	if checksumType == hdfs.ChecksumTypeProto_CHECKSUM_CRC32 {
+		s.checksumTab = crc32.IEEETable
+	} else if checksumType == hdfs.ChecksumTypeProto_CHECKSUM_CRC32C {
+		s.checksumTab = crc32.MakeTable(crc32.Castagnoli)
+	} else {
+		return fmt.Errorf("Unsupported checksum type: %d", checksumType)
+	}
+
+	s.chunkSize = checksumInfo.GetBytesPerChecksum()
+	s.startNewPacket()
+
+	// The read will start aligned to a chunk boundary, so we need to seek forward
+	// to the requested offset.
+	amountToDiscard := s.startOffset - s.packet.blockOffset
+	if amountToDiscard > 0 {
+		io.CopyN(ioutil.Discard, s, int64(amountToDiscard))
+	}
+
+	return nil
+}
+
+func (s *blockStream) Close() {
+	s.conn.Close()
+	s.closed = true
+}
+
+func (s *blockStream) Read(b []byte) (int, error) {
+	if s.closed {
+		return 0, io.ErrClosedPipe
+	}
+
+	// first, read any leftover data from buf
+	if s.buf.Len() > 0 {
+		n, _ := s.buf.Read(b)
+		return n, nil
+	}
+
+	if s.packet.nextChunk >= s.packet.numChunks {
+		if s.packet.last {
+			return 0, io.EOF
+		}
+
+		s.startNewPacket()
+	}
+
+	// then, read until we fill up b or we reach the end of the packet
+	readOffset := 0
+	for s.packet.nextChunk < s.packet.numChunks {
+		chOff := 4 * s.packet.nextChunk
+		checksum := s.packet.checksumBytes[chOff : chOff+4]
+
+		remaining := s.packet.length - s.packet.packetOffset
+		chunkLength := int64(math.Min(float64(s.chunkSize), float64(remaining)))
+
+		chunkReader := io.LimitReader(s.reader, int64(chunkLength))
+		chunkBytes := b[readOffset:]
+		bytesToRead := int(math.Min(float64(len(chunkBytes)), float64(chunkLength)))
+		n, err := io.ReadAtLeast(chunkReader, chunkBytes, bytesToRead)
+
+		readOffset += n
+		s.packet.packetOffset += uint64(n)
+		s.packet.nextChunk++
+
+		if err != nil {
+			s.Close()
+			return readOffset, err
+		}
+
+		crc := crc32.Checksum(chunkBytes[:n], s.checksumTab)
+
+		if int64(n) < chunkLength {
+			// save any leftovers
+			s.buf.Reset()
+			leftover, err := s.buf.ReadFrom(chunkReader)
+			if err != nil {
+				return readOffset, err
+			}
+
+			s.packet.packetOffset += uint64(leftover)
+
+			// update the checksum with the leftovers
+			crc = crc32.Update(crc, s.checksumTab, s.buf.Bytes())
+		}
+
+		if crc != binary.BigEndian.Uint32(checksum) {
+			return readOffset, errors.New("Invalid checksum from the datanode!")
+		}
+
+		if readOffset == len(b) {
+			break
+		}
+	}
+
+	return readOffset, nil
+}
+
+// A read request to a datanode:
+// +-----------------------------------------------------------+
+// |  Data Transfer Protocol Version, int16                    |
+// +-----------------------------------------------------------+
+// |  Op code, 1 byte (READ_BLOCK = 0x51)                      |
+// +-----------------------------------------------------------+
+// |  varint length + OpReadBlockProto                         |
+// +-----------------------------------------------------------+
+func (s *blockStream) writeBlockReadRequest() error {
+	header := []byte{0x00, dataTransferVersion, readBlockOp}
+
+	needed := (s.block.GetB().GetNumBytes() - s.startOffset)
+	op := newReadBlockOp(s.block, s.startOffset, needed)
+	opBytes, err := makeDelimitedMsg(op)
+	if err != nil {
+		return err
+	}
+
+	req := append(header, opBytes...)
+	_, err = s.conn.Write(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// The initial response from the datanode:
+// +-----------------------------------------------------------+
+// |  varint length + BlockOpResponseProto                     |
+// +-----------------------------------------------------------+
+func (s *blockStream) readBlockReadResponse() (*hdfs.BlockOpResponseProto, error) {
+	respLength, err := binary.ReadUvarint(s.reader)
+	if err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+
+		return nil, err
+	}
+
+	respBytes := make([]byte, respLength)
+	_, err = io.ReadFull(s.reader, respBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &hdfs.BlockOpResponseProto{}
+	err = proto.Unmarshal(respBytes, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// A packet from the datanode:
+// +-----------------------------------------------------------+
+// |  uint32 length of the packet                              |
+// +-----------------------------------------------------------+
+// |  size of the PacketHeaderProto, uint16                    |
+// +-----------------------------------------------------------+
+// |  PacketHeaderProto                                        |
+// +-----------------------------------------------------------+
+// |  N checksums, 4 bytes each                                |
+// +-----------------------------------------------------------+
+// |  N chunks of payload data                                 |
+// +-----------------------------------------------------------+
+func (s *blockStream) startNewPacket() error {
+	header, err := s.readPacketHeader()
+	if err != nil {
+		return err
+	}
+
+	blockOffset := uint64(header.GetOffsetInBlock())
+	dataLength := uint64(header.GetDataLen())
+	numChunks := int(math.Ceil(float64(dataLength) / float64(s.chunkSize)))
+
+	// TODO don't assume checksum size is 4
+	s.packet = openPacket{
+		numChunks:     numChunks,
+		nextChunk:     0,
+		checksumBytes: make([]byte, numChunks*4),
+		blockOffset:   blockOffset,
+		packetOffset:  0,
+		length:        dataLength,
+		last:          header.GetLastPacketInBlock(),
+	}
+
+	_, err = io.ReadFull(s.reader, s.packet.checksumBytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *blockStream) readPacketHeader() (*hdfs.PacketHeaderProto, error) {
+	var packetLength uint32
+	err := binary.Read(s.reader, binary.BigEndian, &packetLength)
+	if err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+
+		return nil, err
+	}
+
+	var packetHeaderLength uint16
+	err = binary.Read(s.reader, binary.BigEndian, &packetHeaderLength)
+	if err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+
+		return nil, err
+	}
+
+	packetHeaderBytes := make([]byte, packetHeaderLength)
+	_, err = io.ReadFull(s.reader, packetHeaderBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	packetHeader := &hdfs.PacketHeaderProto{}
+	err = proto.Unmarshal(packetHeaderBytes, packetHeader)
+
+	return packetHeader, nil
+}
+
+func newReadBlockOp(block *hdfs.LocatedBlockProto, offset, length uint64) *hdfs.OpReadBlockProto {
+	return &hdfs.OpReadBlockProto{
+		Header: &hdfs.ClientOperationHeaderProto{
+			BaseHeader: &hdfs.BaseHeaderProto{
+				Block: block.GetB(),
+				Token: block.GetBlockToken(),
+			},
+			ClientName: proto.String(ClientName),
+		},
+		Offset: proto.Uint64(offset),
+		Len:    proto.Uint64(length),
+	}
+}


### PR DESCRIPTION
When a failure happens during reading, we can be robust to that failure by
trying again with the other datanode locations.

Additionally, to prevent us from lots of spurious failures, do some basic global
blacklisting - keep track of datanodes that have failed, and when they last
failed, so we can prioritize datanodes without failures and datanodes that
haven't failed as recently.
