### PR TITLE
Add FileReader.Checksum

### DIFF
--- a/cmd/hdfs/checksum.go
+++ b/cmd/hdfs/checksum.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+func checksum(paths []string) int {
+	expanded, client, err := getClientAndExpandedPaths(paths)
+	if err != nil {
+		fatal(err)
+	}
+
+	for _, p := range expanded {
+		reader, err := client.Open(p)
+		if err != nil {
+			fatal(err)
+		}
+
+		checksum, err := reader.Checksum()
+		if err != nil {
+			fatal(err)
+		}
+
+		fmt.Println(hex.EncodeToString(checksum), p)
+	}
+
+	return 0
+}

--- a/cmd/hdfs/complete.go
+++ b/cmd/hdfs/complete.go
@@ -19,6 +19,7 @@ var knownCommands = []string{
 	"cat",
 	"head",
 	"tail",
+	"checksum",
 	"get",
 	"getmerge",
 }

--- a/cmd/hdfs/main.go
+++ b/cmd/hdfs/main.go
@@ -25,6 +25,7 @@ Valid commands:
   cat SOURCE...
   head [-n LINES | -c BYTES] SOURCE...
   tail [-n LINES | -c BYTES] SOURCE...
+  checksum FILE...
   get SOURCE [DEST]
   getmerge SOURCE DEST
 `, os.Args[0])
@@ -107,6 +108,8 @@ func main() {
 	case "head", "tail":
 		headTailOpts.Parse(argv)
 		status = printSection(headTailOpts.Args(), *headtailn, *headtailc, (command == "tail"))
+	case "checksum":
+		status = checksum(argv[1:])
 	case "get":
 		status = get(argv[1:])
 	case "getmerge":

--- a/cmd/hdfs/test/checksum.bats
+++ b/cmd/hdfs/test/checksum.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load helper
+
+setup() {
+  $HDFS mkdir -p /_test_cmd/checksum/dir
+}
+
+@test "checksum" {
+  FOO_CHECKSUM=$($HADOOP_FS -checksum hdfs://$HADOOP_NAMENODE/_test/foo.txt | awk '{ print substr($3, 25, 32) }')
+
+  run $HDFS checksum /_test/foo.txt
+  assert_success
+  assert_output <<OUT
+$FOO_CHECKSUM /_test/foo.txt
+OUT
+}
+
+@test "checksum nonexistent" {
+  run $HDFS cat /_test_cmd/nonexistent
+  assert_failure
+  assert_output <<OUT
+open /_test_cmd/nonexistent: file does not exist
+OUT
+}
+
+teardown() {
+  $HDFS rm -r /_test_cmd/checksum
+}

--- a/cmd/hdfs/test/helper.bash
+++ b/cmd/hdfs/test/helper.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export HADOOP_DISTRO=${HADOOP_DISTRO-"cdh"}
+export HADOOP_HOME=${HADOOP_HOME-"/tmp/hadoop-$HADOOP_DISTRO"}
 export HADOOP_FS="$HADOOP_HOME/bin/hadoop fs -Ddfs.block.size=1048576"
 export ROOT_TEST_DIR="$BATS_TEST_DIRNAME/../../.."
 export HDFS="$ROOT_TEST_DIR/hdfs"

--- a/file_reader_test.go
+++ b/file_reader_test.go
@@ -2,6 +2,7 @@ package hdfs
 
 import (
 	"bytes"
+	"encoding/hex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"hash/crc32"
@@ -20,6 +21,8 @@ const (
 	testStr2            = "http://www.gutenberg.org"
 	testStr2Off         = 1256988
 	testStr2NegativeOff = -288
+
+	testChecksum = "27c076e4987344253650d3335a5d08ce"
 )
 
 func TestFileRead(t *testing.T) {
@@ -201,4 +204,16 @@ func TestOpenFileWithoutPermission(t *testing.T) {
 	file, err := otherClient.Open("/_test/accessdenied/foo")
 	assert.Nil(t, file)
 	assertPathError(t, err, "open", "/_test/accessdenied/foo", os.ErrPermission)
+}
+
+func TestFileChecksum(t *testing.T) {
+	client := getClient(t)
+
+	file, err := client.Open("/_test/foo.txt")
+	require.Nil(t, err)
+
+	checksum, err := file.Checksum()
+	require.Nil(t, err)
+
+	assert.Equal(t, testChecksum, hex.EncodeToString(checksum))
 }

--- a/rpc/block_stream.go
+++ b/rpc/block_stream.go
@@ -15,11 +15,6 @@ import (
 	"net"
 )
 
-const (
-	dataTransferVersion = 0x1c
-	readBlockOp         = 0x51
-)
-
 // blockStream implements io.ReaderCloser for reading a single block from HDFS,
 // from a single datanode.
 type blockStream struct {
@@ -196,7 +191,7 @@ func (s *blockStream) writeBlockReadRequest() error {
 	header := []byte{0x00, dataTransferVersion, readBlockOp}
 
 	needed := (s.block.GetB().GetNumBytes() - s.startOffset)
-	op := newReadBlockOp(s.block, s.startOffset, needed)
+	op := newBlockReadOp(s.block, s.startOffset, needed)
 	opBytes, err := makeDelimitedMsg(op)
 	if err != nil {
 		return err
@@ -314,7 +309,7 @@ func (s *blockStream) readPacketHeader() (*hdfs.PacketHeaderProto, error) {
 	return packetHeader, nil
 }
 
-func newReadBlockOp(block *hdfs.LocatedBlockProto, offset, length uint64) *hdfs.OpReadBlockProto {
+func newBlockReadOp(block *hdfs.LocatedBlockProto, offset, length uint64) *hdfs.OpReadBlockProto {
 	return &hdfs.OpReadBlockProto{
 		Header: &hdfs.ClientOperationHeaderProto{
 			BaseHeader: &hdfs.BaseHeaderProto{

--- a/rpc/checksum_reader.go
+++ b/rpc/checksum_reader.go
@@ -1,0 +1,144 @@
+package rpc
+
+import (
+	"bufio"
+	"code.google.com/p/goprotobuf/proto"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	hdfs "github.com/colinmarc/hdfs/protocol/hadoop_hdfs"
+	"io"
+	"net"
+)
+
+// ChecksumReader provides an interface for reading the "MD5CRC32" checksums of
+// individual blocks. It abstracts over reading from multiple datanodes, in
+// order to be robust to failures.
+type ChecksumReader struct {
+	block     *hdfs.LocatedBlockProto
+	datanodes *datanodeFailover
+
+	conn   net.Conn
+	reader *bufio.Reader
+}
+
+// NewChecksumReader creates a new ChecksumReader for the given block.
+func NewChecksumReader(block *hdfs.LocatedBlockProto) *ChecksumReader {
+	locs := block.GetLocs()
+	datanodes := make([]string, len(locs))
+	for i, loc := range locs {
+		dn := loc.GetId()
+		datanodes[i] = fmt.Sprintf("%s:%d", dn.GetIpAddr(), dn.GetXferPort())
+	}
+
+	return &ChecksumReader{
+		block:     block,
+		datanodes: newDatanodeFailover(datanodes),
+	}
+}
+
+// ReadChecksum returns the checksum of the block.
+func (cr *ChecksumReader) ReadChecksum() ([]byte, error) {
+	for cr.datanodes.numRemaining() > 0 {
+		address := cr.datanodes.next()
+		checksum, err := cr.readChecksum(address)
+		if err != nil {
+			cr.datanodes.recordFailure(err)
+			continue
+		}
+
+		return checksum, nil
+	}
+
+	err := cr.datanodes.lastError()
+	if err != nil {
+		err = errors.New("No available datanodes for block.")
+	}
+
+	return nil, err
+}
+
+func (cr *ChecksumReader) readChecksum(address string) ([]byte, error) {
+	conn, err := net.DialTimeout("tcp", address, connectionTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	cr.conn = conn
+	err = cr.writeBlockChecksumRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	cr.reader = bufio.NewReader(conn)
+	resp, err := cr.readBlockChecksumResponse()
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.GetChecksumResponse().GetMd5(), nil
+}
+
+// A checksum request to a datanode:
+// +-----------------------------------------------------------+
+// |  Data Transfer Protocol Version, int16                    |
+// +-----------------------------------------------------------+
+// |  Op code, 1 byte (CHECKSUM_BLOCK = 0x55)                  |
+// +-----------------------------------------------------------+
+// |  varint length + OpReadBlockProto                         |
+// +-----------------------------------------------------------+
+func (cr *ChecksumReader) writeBlockChecksumRequest() error {
+	header := []byte{0x00, dataTransferVersion, checksumBlockOp}
+
+	op := newChecksumBlockOp(cr.block)
+	opBytes, err := makeDelimitedMsg(op)
+	if err != nil {
+		return err
+	}
+
+	req := append(header, opBytes...)
+	_, err = cr.conn.Write(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// The response from the datanode:
+// +-----------------------------------------------------------+
+// |  varint length + BlockOpResponseProto                     |
+// +-----------------------------------------------------------+
+func (cr *ChecksumReader) readBlockChecksumResponse() (*hdfs.BlockOpResponseProto, error) {
+	respLength, err := binary.ReadUvarint(cr.reader)
+	if err != nil {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+
+		return nil, err
+	}
+
+	respBytes := make([]byte, respLength)
+	_, err = io.ReadFull(cr.reader, respBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &hdfs.BlockOpResponseProto{}
+	err = proto.Unmarshal(respBytes, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func newChecksumBlockOp(block *hdfs.LocatedBlockProto) *hdfs.OpBlockChecksumProto {
+	return &hdfs.OpBlockChecksumProto{
+		Header: &hdfs.BaseHeaderProto{
+			Block: block.GetB(),
+			Token: block.GetBlockToken(),
+		},
+	}
+}

--- a/rpc/checksum_reader_test.go
+++ b/rpc/checksum_reader_test.go
@@ -1,0 +1,19 @@
+package rpc
+
+import (
+	"encoding/hex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+const testChecksum = "b8d258c1ae6b31ce38b833f7e3bb5cb0"
+
+func TestReadChecksum(t *testing.T) {
+	block := getBlocks(t, "/_test/mobydick.txt")[0]
+	cr := NewChecksumReader(block)
+
+	checksum, err := cr.ReadChecksum()
+	require.Nil(t, err)
+	assert.Equal(t, testChecksum, hex.EncodeToString(checksum))
+}

--- a/rpc/datanode_failover_test.go
+++ b/rpc/datanode_failover_test.go
@@ -1,0 +1,27 @@
+package rpc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestPicksFirstDatanode(t *testing.T) {
+	df := newDatanodeFailover([]string{"foo:6000", "bar:6000"})
+	assert.Equal(t, df.next(), "foo:6000")
+}
+
+func TestPicksDatanodesWithoutFailures(t *testing.T) {
+	df := newDatanodeFailover([]string{"foo:6000", "foo:7000", "bar:6000"})
+	datanodeFailures["foo:6000"] = time.Now()
+
+	assert.Equal(t, df.next(), "foo:7000")
+}
+
+func TestPicksDatanodesWithOldestFailures(t *testing.T) {
+	df := newDatanodeFailover([]string{"foo:6000", "bar:6000"})
+	datanodeFailures["foo:6000"] = time.Now().Add(-10 * time.Minute)
+	datanodeFailures["bar:6000"] = time.Now()
+
+	assert.Equal(t, df.next(), "foo:6000")
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -10,7 +10,12 @@ import (
 
 // ClientName is passed into the namenode on requests, and identifies this
 // client to the namenode.
-const ClientName = "go-hdfs"
+const (
+	ClientName          = "go-hdfs"
+	dataTransferVersion = 0x1c
+	readBlockOp         = 0x51
+	checksumBlockOp     = 0x55
+)
 
 func makeDelimitedMsg(msg proto.Message) ([]byte, error) {
 	msgBytes, err := proto.Marshal(msg)


### PR DESCRIPTION
The FileReader.Checksum method provides access to HDFS's built in checksum
ability, which works by checksumming concatenated checksums which are already
stored alongside the data.

This also adds a datanodeFailover type, to abstract over handling datanode
failure in multiple contexts (reading the checksum is the second such context;
reading blocks was the original one, and writing blocks will eventually be
similar).
