### PR TITLE
Move to new container infrastructure on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ go:
   - 1.3
   - 1.4
 before_install:
-  - sudo add-apt-repository ppa:duggan/bats --yes
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq bats
+  - git clone https://github.com/sstephenson/bats $HOME/bats
+  - mkdir -p $HOME/bats/build
+  - $HOME/bats/install.sh $HOME/bats/build
+  - export PATH="$PATH:$HOME/bats/build/bin"
 install: make get-deps
 env:
   - HADOOP_DISTRO=cdh
@@ -13,8 +14,12 @@ env:
 before_script:
   - export NN_PORT=9000
   - export HADOOP_NAMENODE="localhost:$NN_PORT"
-  - export HADOOP_HOME="hadoop-$HADOOP_DISTRO"
+  - export HADOOP_HOME="$HOME/hadoop-$HADOOP_DISTRO"
   - ./setup_test_env.sh
 script:
   - make test
   - cat minicluster.log
+sudo: false
+cache:
+  - $HADOOP_HOME
+  - $HOME/bats


### PR DESCRIPTION
This requires installing bats manually, since add-apt-repo doesn't work.