### PR TITLE
MkdirAll: Do not return error when already exists

### DIFF
--- a/mkdir.go
+++ b/mkdir.go
@@ -24,8 +24,11 @@ func (c *Client) MkdirAll(dirname string, perm os.FileMode) error {
 func (c *Client) mkdir(dirname string, perm os.FileMode, createParent bool) error {
 	dirname = path.Clean(dirname)
 
-	_, err := c.getFileInfo(dirname)
+	info, err := c.getFileInfo(dirname)
 	if err == nil {
+		if createParent && info.IsDir() {
+			return nil
+		}
 		return &os.PathError{"mkdir", dirname, os.ErrExist}
 	} else if !os.IsNotExist(err) {
 		return &os.PathError{"mkdir", dirname, err}

--- a/mkdir_test.go
+++ b/mkdir_test.go
@@ -64,6 +64,18 @@ func TestMkdirAll(t *testing.T) {
 	assert.EqualValues(t, 0, fi.Size())
 }
 
+func TestMkdirAllExists(t *testing.T) {
+	client := getClient(t)
+
+	baleet(t, "/_test/dir4")
+
+	err := client.MkdirAll("/_test/dir4/foo", mode)
+	require.NoError(t, err)
+
+	err := client.MkdirAll("/_test/dir4/foo", mode)
+	require.NoError(t, err)
+}
+
 func TestMkdirWIthoutPermission(t *testing.T) {
 	client := getClient(t)
 	otherClient := getClientForUser(t, "other")


### PR DESCRIPTION
Documentation states that MkdirAll does not return error when directory
already exists, however is not. Fix MkdirAll to return nil when
directory already exists.