### PR TITLE
fetch getopt from github instead of googlecode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 
 get-deps:
 	go get github.com/golang/protobuf/proto
-	go get code.google.com/p/getopt
+	go get github.com/pborman/getopt
 	go get github.com/stretchr/testify/assert
 	go get github.com/stretchr/testify/require
 

--- a/cmd/hdfs/main.go
+++ b/cmd/hdfs/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"code.google.com/p/getopt"
 	"errors"
 	"fmt"
 	"github.com/colinmarc/hdfs"
+	"github.com/pborman/getopt"
 	"os"
 )
 


### PR DESCRIPTION
`getopt` package is moved to github, so there's no reason to use old
code.google.com link. It also removes mercurial dependency on installing
`hdfs` command.