### PR TITLE
A workaround to support building of non-official forks of the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
+THIS_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+PROJECT_NAME=github.com/colinmarc/hdfs
+PROJECT_GOPATH_DIR=$(GOPATH)/src/$(PROJECT_NAME)
+
 all: hdfs
 
-hdfs: get-deps clean
+hdfs: get-deps clean $(PROJECT_GOPATH_DIR)
 	go build ./cmd/hdfs
+
+$(PROJECT_GOPATH_DIR):
+	# this symlink workaround is needed to support building of non-official forks of the project
+	mkdir -p $(shell dirname $(PROJECT_GOPATH_DIR))
+	ln -s $(THIS_DIR) $(PROJECT_GOPATH_DIR)
 
 install: get-deps
 	go install ./...


### PR DESCRIPTION
What do you think about accepting the following workaround ?

This change passed in travis setup for my fork:
https://travis-ci.org/vlivan-microsoft/colinmarc-hdfs/builds/104363692

This addresses the following issue:

https://travis-ci.org/vlivan-microsoft/colinmarc-hdfs/builds/104338935
go build ./cmd/hdfs
cmd/hdfs/cat.go:10:2: cannot find package "github.com/colinmarc/hdfs" in any of:
	/home/travis/.gimme/versions/go1.4.linux.amd64/src/github.com/colinmarc/hdfs (from $GOROOT)
	/home/travis/gopath/src/github.com/colinmarc/hdfs (from $GOPATH)
make: *** [hdfs] Error 1
