### PR TITLE
Fix ls -l format

### DIFF
--- a/cmd/hdfs/ls.go
+++ b/cmd/hdfs/ls.go
@@ -140,7 +140,7 @@ func printLong(tw *tabwriter.Writer, name string, info os.FileInfo, humanReadabl
 	}
 
 	modtime := fi.ModTime()
-	date := modtime.Format("Jan\t2")
+	date := modtime.Format("Jan _2")
 	var timeOrYear string
 	if modtime.Year() == time.Now().Year() {
 		timeOrYear = modtime.Format("15:04")


### PR DESCRIPTION
`ls -l` prints Month Day incorrectly for 2-digit dates.  Use the _ empty
padding method to format the Month and Day.