### PR TITLE
Added Close semantics to hdfs.Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -117,3 +117,8 @@ func (c *Client) fetchDefaults() (*hdfs.FsServerDefaultsProto, error) {
 	c.defaults = resp.GetServerDefaults()
 	return c.defaults, nil
 }
+
+// Close terminates all underlying socket connections to remote server.
+func (c *Client) Close() error {
+	return c.namenode.Close()
+}

--- a/rpc/namenode.go
+++ b/rpc/namenode.go
@@ -226,6 +226,11 @@ func (c *NamenodeConnection) writeNamenodeHandshake() error {
 	return err
 }
 
+// Close terminates all underlying socket connections to remote server.
+func (c *NamenodeConnection) Close() error {
+	return c.conn.Close()
+}
+
 func newRPCRequestHeader(id int, clientID []byte) *hadoop.RpcRequestHeaderProto {
 	return &hadoop.RpcRequestHeaderProto{
 		RpcKind:  hadoop.RpcKindProto_RPC_PROTOCOL_BUFFER.Enum(),


### PR DESCRIPTION
when using hdfs.Client I noticed that operations against a hdfs cluster that had gone down and back up failed because the connection had been closed, of the form:

> write tcp 127.0.0.1:52538->127.0.0.1:9003: use of closed network connection

I've read through godoc on the library, and delved in a bit into the code, and I don't see any logic for reconnections or retries. Is it intended that if I loose a connection that I retry in the code?

Basically I've considered just opening a new connection for each operation to have tighter guarantees that it'll be live when needed. To this end I've added a .Close to hdfs.Client and rpc.NamenodeConnection, hence this PR.

I figured try the simplest possible solution before I went about having retry semantics all over my code; just making one connection per request seemed fairly straightforward. Does my approach seem wasteful? Do you have any other suggestions on how to recover from the lost connection?