### PR TITLE
Fixed incorrect Append implementation.

### DIFF
--- a/file_writer.go
+++ b/file_writer.go
@@ -90,8 +90,8 @@ func (c *Client) Append(name string) (*FileWriter, error) {
 	}
 
 	appendReq := &hdfs.AppendRequestProto{
-		Src:          proto.String(name),
-		ClientName:   proto.String(c.namenode.ClientName()),
+		Src:        proto.String(name),
+		ClientName: proto.String(c.namenode.ClientName()),
 	}
 	appendResp := &hdfs.AppendResponseProto{}
 
@@ -124,14 +124,11 @@ func (c *Client) Append(name string) (*FileWriter, error) {
 		blockSize:   int64(appendResp.Stat.GetBlocksize()),
 	}
 	if len(blocks) == 0 {
-		// This file has no blocks associated with it, we don't need to
-		// bother with setting the current block.
 		return f, nil
 	}
-	// This file has previous blocks, but they are immutable. We must setup
-	// a reference to the last block, then start a new block.
-	f.block = blocks[len(blocks) - 1]
-	return f, f.startNewBlock()
+	f.block = blocks[len(blocks)-1]
+	f.blockWriter = rpc.NewBlockWriter(f.block, c.namenode, f.blockSize)
+	return f, nil
 }
 
 // CreateEmptyFile creates a empty file at the given name, with the

--- a/rpc/block_write_stream.go
+++ b/rpc/block_write_stream.go
@@ -57,10 +57,10 @@ func (ae ackError) Error() string {
 
 var ErrInvalidSeqno = errors.New("Invalid ack sequence number")
 
-func newBlockWriteStream(conn io.ReadWriter) *blockWriteStream {
+func newBlockWriteStream(conn io.ReadWriter, offset int64) *blockWriteStream {
 	s := &blockWriteStream{
 		conn:     conn,
-		offset:   0,
+		offset:   offset,
 		seqno:    1,
 		packets:  make(chan outboundPacket, maxPacketsInQueue),
 		acksDone: make(chan struct{}),

--- a/rpc/block_writer.go
+++ b/rpc/block_writer.go
@@ -25,6 +25,7 @@ type BlockWriter struct {
 	stream   *blockWriteStream
 	offset   int64
 	closed   bool
+	append   bool
 }
 
 // NewBlockWriter returns a BlockWriter for the given block. It will lazily
@@ -36,6 +37,12 @@ func NewBlockWriter(block *hdfs.LocatedBlockProto, namenode *NamenodeConnection,
 		block:      block,
 		blockSize:  blockSize,
 		namenode:   namenode,
+	}
+
+	if o := block.B.GetNumBytes(); o > 0 {
+		// The block already contains data; we are appending.
+		s.offset = int64(o)
+		s.append = true
 	}
 
 	return s
@@ -121,7 +128,7 @@ func (bw *BlockWriter) connectNext() error {
 	}
 
 	bw.conn = conn
-	bw.stream = newBlockWriteStream(conn)
+	bw.stream = newBlockWriteStream(conn, bw.offset)
 	return nil
 }
 
@@ -144,12 +151,20 @@ func (bw *BlockWriter) currentPipeline() []*hdfs.DatanodeInfoProto {
 }
 
 func (bw *BlockWriter) currentStage() hdfs.OpWriteBlockProto_BlockConstructionStage {
-	// TODO: this should be PIPELINE_SETUP_STREAMING_RECOVERY for recovery
+	// TODO: this should be PIPELINE_SETUP_STREAMING_RECOVERY or
+	// PIPELINE_SETUP_APPEND_RECOVERY for recovery.
+	if bw.append {
+		return hdfs.OpWriteBlockProto_PIPELINE_SETUP_APPEND
+	}
 	return hdfs.OpWriteBlockProto_PIPELINE_SETUP_CREATE
 }
 
 func (bw *BlockWriter) generationTimestamp() int64 {
-	// TODO: ???
+	// TODO: This needs to be incremented only when appending to
+	// an existing block.
+	if bw.append {
+		return int64(bw.block.B.GetGenerationStamp() + 1)
+	}
 	return 0
 }
 
@@ -169,6 +184,17 @@ func (bw *BlockWriter) finalizeBlock(length int64) error {
 	return nil
 }
 
+// writeBlockWriteRequest creates an OpWriteBlock message and submits it to the
+// datanode. This occurs before any writing actually occurs, and is intended
+// to synchronize the client with the datanode, returning an error if the
+// submitted expected state differs from the actual state on the datanode.
+//
+// The field "MinBytesRcvd" below is used during append operation and should be
+// the block's expected size. The field "MaxBytesRcvd" is used only in the case
+// of PIPELINE_SETUP_STREAMING_RECOVERY.
+//
+// See: https://github.com/apache/hadoop/blob/6314843881b4c67d08215e60293f8b33242b9416/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/BlockReceiver.java#L216
+// And: https://github.com/apache/hadoop/blob/6314843881b4c67d08215e60293f8b33242b9416/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/FsDatasetImpl.java#L1462
 func (bw *BlockWriter) writeBlockWriteRequest(w io.Writer) error {
 	targets := bw.currentPipeline()[1:]
 
@@ -184,7 +210,7 @@ func (bw *BlockWriter) writeBlockWriteRequest(w io.Writer) error {
 		Stage:                 bw.currentStage().Enum(),
 		PipelineSize:          proto.Uint32(uint32(len(targets))),
 		MinBytesRcvd:          proto.Uint64(bw.block.GetB().GetNumBytes()),
-		MaxBytesRcvd:          proto.Uint64(uint64(bw.offset)), // I don't understand these two fields
+		MaxBytesRcvd:          proto.Uint64(uint64(bw.offset)),
 		LatestGenerationStamp: proto.Uint64(uint64(bw.generationTimestamp())),
 		RequestedChecksum: &hdfs.ChecksumProto{
 			Type:             hdfs.ChecksumTypeProto_CHECKSUM_CRC32.Enum(),


### PR DESCRIPTION
The previous implementation considered existing blocks immutable, which is not
correct. It is possible to append to an existing block by unfinalizing it prior to writing.

This commit attempts to unfinalize the last existing block during an append
operation so that it may be written to again. This is done by submitting the
correct stage `hdfs.OpWriteBlockProto_PIPELINE_SETUP_APPEND` during the
initial OpWriteBlock operation. Additionally, `blockWriteStream`s are now
always initialized with an offset, which will be > 0 in case of append
operation. Finally, the GenerationStamp field is incremented at the beginning
of the append operation, which is an incrementing integer that records the
version of a particular block.