### PR TITLE
While appending, use the same generation stamp sent by the namenode

### DIFF
--- a/rpc/block_writer.go
+++ b/rpc/block_writer.go
@@ -163,7 +163,7 @@ func (bw *BlockWriter) generationTimestamp() int64 {
 	// TODO: This needs to be incremented only when appending to
 	// an existing block.
 	if bw.append {
-		return int64(bw.block.B.GetGenerationStamp() + 1)
+		return int64(bw.block.B.GetGenerationStamp())
 	}
 	return 0
 }


### PR DESCRIPTION
While trying out the append functionality ran into the issue where the datanode was complaining about generation stamp(gs) mismatch, and looks like gs must be same as sent by namenode. After changing this way the append works fine.