### PR TITLE
Don't increment the generation timestamp when appending

### DIFF
--- a/file_writer_test.go
+++ b/file_writer_test.go
@@ -304,3 +304,46 @@ func TestFileAppendLastBlockFull(t *testing.T) {
 
 	assert.Equal(t, "\nfoo", string(buf))
 }
+
+func TestFileAppendTwice(t *testing.T) {
+	client := getClient(t)
+
+	baleet(t, "/_test/append/4.txt")
+	mkdirp(t, "/_test/append")
+	writer, err := client.Create("/_test/append/4.txt")
+	require.NoError(t, err)
+
+	n, err := writer.Write([]byte("foo"))
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	err = writer.Close()
+	require.NoError(t, err)
+
+	writer, err = client.Append("/_test/append/4.txt")
+	require.NoError(t, err)
+
+	n, err = writer.Write([]byte("bar"))
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	err = writer.Close()
+	require.NoError(t, err)
+
+	writer, err = client.Append("/_test/append/4.txt")
+	require.NoError(t, err)
+
+	n, err = writer.Write([]byte("baz"))
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	err = writer.Close()
+	require.NoError(t, err)
+
+	reader, err := client.Open("/_test/append/4.txt")
+	require.NoError(t, err)
+
+	bytes, err := ioutil.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "foobarbaz", string(bytes))
+}

--- a/rpc/block_writer.go
+++ b/rpc/block_writer.go
@@ -160,10 +160,8 @@ func (bw *BlockWriter) currentStage() hdfs.OpWriteBlockProto_BlockConstructionSt
 }
 
 func (bw *BlockWriter) generationTimestamp() int64 {
-	// TODO: This needs to be incremented only when appending to
-	// an existing block.
 	if bw.append {
-		return int64(bw.block.B.GetGenerationStamp() + 1)
+		return int64(bw.block.B.GetGenerationStamp())
 	}
 	return 0
 }


### PR DESCRIPTION
This adds a test covering an error the namenode returns when we try to append twice to the existing block, and a fix for it (which I confess to not really understanding).

@tyler-sommer, this seems to directly contradict the comment you left, so what do you think? Does this seem right?