### PR TITLE
Clobber in rename: provide overwrite option in Rename

### DIFF
--- a/cmd/hdfs/mv.go
+++ b/cmd/hdfs/mv.go
@@ -57,14 +57,18 @@ func moveInto(client *hdfs.Client, sources []string, dest string, force bool) {
 }
 
 func moveTo(client *hdfs.Client, source, dest string, force bool) {
+	resp, err := client.Stat(dest)
 	if force {
-		err := client.Remove(dest)
-		if err != nil && !os.IsNotExist(err) {
-			fatal(err)
+		if err == nil && resp.IsDir() {
+			if err = client.Remove(dest); err != nil {
+				fatal(err)
+			}
 		}
+	} else if err == nil {
+		fatal(&os.PathError{"rename", dest, os.ErrExist})
 	}
 
-	err := client.Rename(source, dest)
+	err = client.Rename(source, dest)
 	if err != nil {
 		fatal(err)
 	}

--- a/rename.go
+++ b/rename.go
@@ -11,9 +11,7 @@ import (
 // Rename renames (moves) a file.
 func (c *Client) Rename(oldpath, newpath string) error {
 	_, err := c.getFileInfo(newpath)
-	if err == nil {
-		return &os.PathError{"rename", newpath, os.ErrExist}
-	} else if !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(err) {
 		return &os.PathError{"rename", newpath, err}
 	}
 

--- a/rename_test.go
+++ b/rename_test.go
@@ -42,7 +42,7 @@ func TestRenameDestExists(t *testing.T) {
 	touch(t, "/_test/tomovedest2")
 
 	err := client.Rename("/_test/tomove2", "/_test/tomovedest2")
-	assertPathError(t, err, "rename", "/_test/tomovedest2", os.ErrExist)
+	require.NoError(t, err)
 }
 
 func TestRenameWithoutPermissionForSrc(t *testing.T) {


### PR DESCRIPTION
Right now, rename api cannot overwrite the existing file, according to https://github.com/colinmarc/hdfs/blob/master/rename.go#L14.

This patch allows users to decide whether to overwrite files if the files already exist.