### PR TITLE
Reconstruct the pipeline for block write when one or more datanodes failed

### DIFF
--- a/file_writer.go
+++ b/file_writer.go
@@ -127,7 +127,7 @@ func (c *Client) Append(name string) (*FileWriter, error) {
 		return f, nil
 	}
 	f.block = blocks[len(blocks)-1]
-	f.blockWriter = rpc.NewBlockWriter(f.block, c.namenode, f.blockSize)
+	f.blockWriter = rpc.NewBlockWriter(f.block, c.namenode, f.blockSize, f.name)
 	return f, nil
 }
 
@@ -190,7 +190,7 @@ func (f *FileWriter) Close() error {
 			return err
 		}
 
-		lastBlock = f.block.GetB()
+		lastBlock = f.blockWriter.Getblock().GetB()
 	}
 
 	completeReq := &hdfs.CompleteRequestProto{
@@ -239,6 +239,6 @@ func (f *FileWriter) startNewBlock() error {
 	}
 
 	f.block = addBlockResp.GetBlock()
-	f.blockWriter = rpc.NewBlockWriter(f.block, f.client.namenode, f.blockSize)
+	f.blockWriter = rpc.NewBlockWriter(f.block, f.client.namenode, f.blockSize, f.name)
 	return nil
 }

--- a/rpc/block_writer_test.go
+++ b/rpc/block_writer_test.go
@@ -41,7 +41,7 @@ func createBlock(t *testing.T, name string) *BlockWriter {
 	require.NoError(t, err)
 
 	block := addBlockResp.GetBlock()
-	return NewBlockWriter(block, namenode, blockSize)
+	return NewBlockWriter(block, namenode, blockSize, name)
 }
 
 func finishBlock(t *testing.T, name string, bw *BlockWriter) {
@@ -76,8 +76,6 @@ func baleet(t *testing.T, name string) {
 }
 
 func TestWriteFailsOver(t *testing.T) {
-	t.Skip("Write failover isn't implemented")
-
 	name := "/_test/create/6.txt"
 	baleet(t, name)
 

--- a/rpc/block_writer_test.go
+++ b/rpc/block_writer_test.go
@@ -76,6 +76,8 @@ func baleet(t *testing.T, name string) {
 }
 
 func TestWriteFailsOver(t *testing.T) {
+	t.Skip("Write failover isn't implemented")
+
 	name := "/_test/create/6.txt"
 	baleet(t, name)
 


### PR DESCRIPTION
This patch is for block write can still proceed when one or more datanodes failed. The idea is, first identify the failed datanodes, second abandon the block, third request the new block and exclude the identified failed ones.

This is tested work correctly locally when one or more datanodes fail. But somehow, it cannot pass the `block_writer_test`, and I think it is caused by `bw.stream.ackError = ackError{0, 0, hdfs.Status_ERROR}`, which I am not sure how to correctly handle.