### PR TITLE
`truncate` support

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -189,7 +189,7 @@ func TestCopyToRemote(t *testing.T) {
 
 	baleet(t, "/_test/copytoremote.txt")
 	err := client.CopyToRemote("testdata/foo.txt", "/_test/copytoremote.txt")
-	require.NoError(t, err)
+	ignoreErrReplicating(t, err)
 
 	bytes, err := client.ReadFile("/_test/copytoremote.txt")
 	require.NoError(t, err)

--- a/cmd/hdfs/main.go
+++ b/cmd/hdfs/main.go
@@ -38,6 +38,7 @@ Valid commands:
   getmerge SOURCE DEST
   put SOURCE DEST
   df [-h]
+  truncate SIZE FILE
 `, os.Args[0])
 
 	lsOpts = getopt.New()
@@ -147,6 +148,8 @@ func main() {
 	case "df":
 		dfOpts.Parse(argv)
 		df(*dfh)
+	case "truncate":
+		truncate(argv[1:])
 	// it's a seeeeecret command
 	case "complete":
 		complete(argv)

--- a/cmd/hdfs/test/truncate.bats
+++ b/cmd/hdfs/test/truncate.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+load helper
+
+setup() {
+  $HDFS mkdir -p /_test_cmd/truncate
+  $HDFS touch /_test_cmd/truncate/a
+}
+
+@test "truncate larger" {
+  run $HDFS truncate 10 /_test_cmd/a
+  assert_failure
+}
+
+@test "truncate nonexistent" {
+  run $HDSF truncate 10 /_test_cmd/nonexistent
+  assert_failure
+}
+
+@test "truncate" {
+  run $HDFS put $ROOT_TEST_DIR/testdata/foo.txt /_test_cmd/truncate/1
+  run $HDFS truncate 2 /_test_cmd/truncate/1
+  assert_success
+}
+
+teardown() {
+  $HDFS rm -r /_test_cmd/truncate
+}

--- a/cmd/hdfs/truncate.go
+++ b/cmd/hdfs/truncate.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"github.com/colinmarc/hdfs/v2"
+	"os"
+	"strconv"
+)
+
+func truncate(args []string) {
+	if len(args) != 2 {
+		fatalWithUsage()
+	}
+
+	size, err := strconv.ParseInt(args[0], 10, 64)
+	if err != nil {
+		fatal(err)
+	}
+
+	client, err := getClient("")
+	if err != nil {
+		fatal(err)
+	}
+
+	err = client.Truncate(args[1], size)
+	if pe, ok := err.(*os.PathError); ok && pe.Err == hdfs.ErrTruncateAsync {
+		return
+	} else if err != nil {
+		fatal(err)
+	}
+}

--- a/error.go
+++ b/error.go
@@ -11,6 +11,7 @@ const (
 	pathIsNotEmptyDirException   = "org.apache.hadoop.fs.PathIsNotEmptyDirectoryException"
 	fileAlreadyExistsException   = "org.apache.hadoop.fs.FileAlreadyExistsException"
 	alreadyBeingCreatedException = "org.apache.hadoop.hdfs.protocol.AlreadyBeingCreatedException"
+	illegalArgumentException     = "org.apache.hadoop.HadoopIllegalArgumentException"
 )
 
 // Error represents a remote java exception from an HDFS namenode or datanode.
@@ -50,6 +51,8 @@ func interpretException(err error) error {
 		return syscall.ENOTEMPTY
 	case fileAlreadyExistsException:
 		return os.ErrExist
+	case illegalArgumentException:
+		return os.ErrInvalid
 	default:
 		return err
 	}

--- a/file_writer_test.go
+++ b/file_writer_test.go
@@ -15,31 +15,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const abcException = "org.apache.hadoop.hdfs.protocol.AlreadyBeingCreatedException"
-
-func appendIgnoreABC(t *testing.T, client *Client, path string) (*FileWriter, error) {
-	// This represents a bug in the HDFS append implementation, as far as I can
-	// tell. Try a few times again, then skip the test.
-	retries := 0
-	for {
-		fw, err := client.Append(path)
-
-		if pathErr, ok := err.(*os.PathError); ok {
-			if nnErr, ok := pathErr.Err.(Error); ok && nnErr.Exception() == abcException {
-				t.Log("Ignoring AlreadyBeingCreatedException from append")
-
-				if retries < 3 {
-					retries += 1
-					continue
-				} else {
-					t.Skip("skipping Append test because of repeated AlreadyBeingCreatedException")
-					return fw, nil
-				}
-			}
+func assertClose(t *testing.T, w *FileWriter) {
+	var err error
+	for i := 0; i < 5; i++ {
+		err := w.Close()
+		if pe, ok := err.(*os.PathError); ok && pe.Err == ErrReplicating {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		} else {
+			break
 		}
-
-		return fw, err
 	}
+
+	assert.NoError(t, err)
+}
+
+func ignoreErrReplicating(t *testing.T, err error) {
+	if pe, ok := err.(*os.PathError); ok && pe.Err == ErrReplicating {
+		return
+	}
+
+	require.NoError(t, err)
 }
 
 func TestFileWrite(t *testing.T) {
@@ -56,9 +52,7 @@ func TestFileWrite(t *testing.T) {
 	n, err = writer.Write([]byte("bar"))
 	require.NoError(t, err)
 	assert.Equal(t, 3, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/create/1.txt")
 	require.NoError(t, err)
@@ -89,9 +83,7 @@ func TestFileWriteLeaseRenewal(t *testing.T) {
 	n, err = writer.Write([]byte("bar"))
 	require.NoError(t, err)
 	assert.Equal(t, 3, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/create/1.txt")
 	require.NoError(t, err)
@@ -114,9 +106,7 @@ func TestFileBigWrite(t *testing.T) {
 	n, err := io.Copy(writer, mobydick)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1257276, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/create/2.txt")
 	require.NoError(t, err)
@@ -141,9 +131,7 @@ func TestFileBigWriteMultipleBlocks(t *testing.T) {
 	n, err := io.Copy(writer, mobydick)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1257276, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/create/3.txt")
 	require.NoError(t, err)
@@ -168,9 +156,7 @@ func TestFileBigWriteWeirdBlockSize(t *testing.T) {
 	n, err := io.Copy(writer, mobydick)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1257276, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/create/4.txt")
 	require.NoError(t, err)
@@ -195,9 +181,7 @@ func TestFileBigWriteReplication(t *testing.T) {
 	n, err := io.Copy(writer, mobydick)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1257276, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/create/5.txt")
 	require.NoError(t, err)
@@ -241,9 +225,7 @@ func TestFileWriteSmallFlushes(t *testing.T) {
 	n, err = writer.Write([]byte(s))
 	require.NoError(t, err, "final write of %d bytes", len(s))
 	assert.Equal(t, len(s), n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/create/6.txt")
 	require.NoError(t, err)
@@ -260,7 +242,7 @@ func TestCreateEmptyFile(t *testing.T) {
 	baleet(t, "/_test/emptyfile")
 
 	err := client.CreateEmptyFile("/_test/emptyfile")
-	require.NoError(t, err)
+	ignoreErrReplicating(t, err)
 
 	fi, err := client.Stat("/_test/emptyfile")
 	require.NoError(t, err)
@@ -281,7 +263,7 @@ func TestCreateFileAlreadyExistsException(t *testing.T) {
 
 	f, err := client.CreateFile(filePath, 1, 1048576, 0755)
 	require.NoError(t, err)
-	require.NoError(t, f.Close())
+	assertClose(t, f)
 
 	_, err = client.CreateFile(filePath, 1, 1048576, 0755)
 	assertPathError(t, err, "create", filePath, os.ErrExist) // org.apache.hadoop.fs.FileAlreadyExistsException is received from HDFS
@@ -298,7 +280,7 @@ func TestCreateFileAlreadyBeingCreatedException(t *testing.T) {
 	f, err := client.CreateFile(filePath, 1, 1048576, 0755)
 	require.NoError(t, err)
 	defer func() {
-		require.NoError(t, f.Close())
+		assertClose(t, f)
 	}()
 
 	_, err = client.CreateFile(filePath, 1, 1048576, 0755)
@@ -340,11 +322,9 @@ func TestFileAppend(t *testing.T) {
 	n, err := writer.Write([]byte("foobar\n"))
 	require.NoError(t, err)
 	assert.Equal(t, 7, n)
+	assertClose(t, writer)
 
-	err = writer.Close()
-	require.NoError(t, err)
-
-	writer, err = appendIgnoreABC(t, client, "/_test/append/1.txt")
+	writer, err = client.Append("/_test/append/1.txt")
 	require.NoError(t, err)
 
 	n, err = writer.Write([]byte("foo"))
@@ -354,9 +334,7 @@ func TestFileAppend(t *testing.T) {
 	n, err = writer.Write([]byte("baz"))
 	require.NoError(t, err)
 	assert.Equal(t, 3, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/append/1.txt")
 	require.NoError(t, err)
@@ -371,9 +349,9 @@ func TestFileAppendEmptyFile(t *testing.T) {
 
 	mkdirp(t, "/_test/append")
 	err := client.CreateEmptyFile("/_test/append/2.txt")
-	require.NoError(t, err)
+	ignoreErrReplicating(t, err)
 
-	writer, err := appendIgnoreABC(t, client, "/_test/append/2.txt")
+	writer, err := client.Append("/_test/append/2.txt")
 	require.NoError(t, err)
 
 	n, err := writer.Write([]byte("foo"))
@@ -383,9 +361,7 @@ func TestFileAppendEmptyFile(t *testing.T) {
 	n, err = writer.Write([]byte("bar"))
 	require.NoError(t, err)
 	assert.Equal(t, 3, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/append/2.txt")
 	require.NoError(t, err)
@@ -409,19 +385,15 @@ func TestFileAppendLastBlockFull(t *testing.T) {
 	wn, err := io.CopyN(writer, mobydick, 1048576)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1048576, wn)
+	assertClose(t, writer)
 
-	err = writer.Close()
-	require.NoError(t, err)
-
-	writer, err = appendIgnoreABC(t, client, "/_test/append/3.txt")
+	writer, err = client.Append("/_test/append/3.txt")
 	require.NoError(t, err)
 
 	n, err := writer.Write([]byte("\nfoo"))
 	require.NoError(t, err)
 	assert.Equal(t, 4, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	reader, err := client.Open("/_test/append/3.txt")
 	require.NoError(t, err)
@@ -449,13 +421,11 @@ func TestFileAppendRepeatedly(t *testing.T) {
 	n, err := writer.Write([]byte("foo"))
 	require.NoError(t, err)
 	assert.Equal(t, 3, n)
-
-	err = writer.Close()
-	require.NoError(t, err)
+	assertClose(t, writer)
 
 	expected := "foo"
 	for i := 0; i < 20; i++ {
-		writer, err = appendIgnoreABC(t, client, "/_test/append/4.txt")
+		writer, err = client.Append("/_test/append/4.txt")
 		require.NoError(t, err)
 
 		s := strings.Repeat("b", rand.Intn(1024)) + "\n"
@@ -522,11 +492,9 @@ func TestFileAppendDeadline(t *testing.T) {
 	n, err := writer.Write([]byte("foobar\n"))
 	require.NoError(t, err)
 	assert.Equal(t, 7, n)
+	assertClose(t, writer)
 
-	err = writer.Close()
-	require.NoError(t, err)
-
-	writer, err = appendIgnoreABC(t, client, "/_test/append/5.txt")
+	writer, err = client.Append("/_test/append/5.txt")
 	require.NoError(t, err)
 
 	writer.SetDeadline(time.Now().Add(100 * time.Millisecond))
@@ -554,11 +522,9 @@ func TestFileAppendDeadlineBefore(t *testing.T) {
 	n, err := writer.Write([]byte("foobar\n"))
 	require.NoError(t, err)
 	assert.Equal(t, 7, n)
+	assertClose(t, writer)
 
-	err = writer.Close()
-	require.NoError(t, err)
-
-	writer, err = appendIgnoreABC(t, client, "/_test/append/6.txt")
+	writer, err = client.Append("/_test/append/6.txt")
 	require.NoError(t, err)
 
 	writer.SetDeadline(time.Now())

--- a/truncate.go
+++ b/truncate.go
@@ -1,0 +1,35 @@
+package hdfs
+
+import (
+	"errors"
+	"os"
+
+	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	"google.golang.org/protobuf/proto"
+)
+
+var ErrTruncateAsync = errors.New("truncate currently in progress")
+
+// Truncate truncates the file specified by name to the given size, and returns
+// any error encountered. If HDFS indicates the truncate will be performed
+// asynchronously, the error returned will be ErrTruncateAsync wrapped in an
+// os.PathError.
+func (c *Client) Truncate(name string, size int64) error {
+	req := &hdfs.TruncateRequestProto{
+		Src:        proto.String(name),
+		NewLength:  proto.Uint64(uint64(size)),
+		ClientName: proto.String(c.namenode.ClientName),
+	}
+	resp := &hdfs.TruncateResponseProto{}
+
+	err := c.namenode.Execute("truncate", req, resp)
+	if err != nil {
+		return &os.PathError{"truncate", name, interpretException(err)}
+	} else if resp.Result == nil {
+		return &os.PathError{"truncate", name, errors.New("unexpected empty response")}
+	} else if resp.GetResult() == false {
+		return &os.PathError{"truncate", name, ErrTruncateAsync}
+	}
+
+	return nil
+}

--- a/truncate_test.go
+++ b/truncate_test.go
@@ -1,0 +1,149 @@
+package hdfs
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func waitTruncate(t *testing.T, client *Client, name string, expectedSize int64) {
+	for i := 0; i < 5; i++ {
+		stat, err := client.Stat(name)
+		require.NoError(t, err)
+
+		if stat.Size() == expectedSize {
+			assert.EqualValues(t, expectedSize, stat.Size())
+			break
+		}
+
+		time.Sleep(500 * time.Millisecond)
+		t.Log("Waiting for truncate to finish")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	client := getClient(t)
+
+	baleet(t, "/_test/truncate/1.txt")
+	mkdirp(t, "/_test/truncate")
+	f, err := client.Create("/_test/truncate/1.txt")
+	require.NoError(t, err)
+
+	n, err := f.Write([]byte("foobar\nfoobar\n"))
+	assert.Equal(t, 14, n)
+	require.NoError(t, err)
+
+	assertClose(t, f)
+
+	err = client.Truncate("/_test/truncate/1.txt", 4)
+
+	if pe, ok := err.(*os.PathError); ok && pe.Err == ErrTruncateAsync {
+		waitTruncate(t, client, "/_test/truncate/1.txt", 4)
+	} else {
+		require.NoError(t, err)
+	}
+}
+
+func TestTruncateToZero(t *testing.T) {
+	client := getClient(t)
+
+	baleet(t, "/_test/truncate/2.txt")
+	mkdirp(t, "/_test/truncate")
+	f, err := client.Create("/_test/truncate/2.txt")
+	require.NoError(t, err)
+
+	n, err := f.Write([]byte("foobarbaz"))
+	assert.Equal(t, 9, n)
+	require.NoError(t, err)
+
+	assertClose(t, f)
+
+	err = client.Truncate("/_test/truncate/2.txt", 0)
+
+	if err == ErrTruncateAsync {
+		waitTruncate(t, client, "/_test/truncate/2.txt", 0)
+	} else {
+		require.NoError(t, err)
+	}
+}
+
+func TestTruncateSizeTooBig(t *testing.T) {
+	client := getClient(t)
+
+	baleet(t, "/_test/truncate/3.txt")
+	mkdirp(t, "/_test/truncate")
+
+	f, err := client.Create("/_test/truncate/3.txt")
+	require.NoError(t, err)
+
+	n, err := f.Write([]byte("foo"))
+	assert.Equal(t, 3, n)
+	require.NoError(t, err)
+
+	assertClose(t, f)
+
+	err = client.Truncate("/_test/truncate/3.txt", 100)
+	assertPathError(t, err, "truncate", "/_test/truncate/3.txt", os.ErrInvalid)
+}
+
+func TestTruncateSizeNegative(t *testing.T) {
+	client := getClient(t)
+
+	baleet(t, "/_test/truncate/4.txt")
+	mkdirp(t, "/_test/truncate")
+
+	f, err := client.Create("/_test/truncate/4.txt")
+	require.NoError(t, err)
+
+	n, err := f.Write([]byte("foo"))
+	assert.Equal(t, 3, n)
+	require.NoError(t, err)
+
+	assertClose(t, f)
+
+	err = client.Truncate("/_test/truncate/4.txt", -10)
+	assertPathError(t, err, "truncate", "/_test/truncate/4.txt", os.ErrInvalid)
+}
+
+func TestTruncateNoExist(t *testing.T) {
+	client := getClient(t)
+
+	err := client.Truncate("/_test/nonexistent", 100)
+	assertPathError(t, err, "truncate", "/_test/nonexistent", os.ErrNotExist)
+}
+
+func TestTruncateDir(t *testing.T) {
+	client := getClient(t)
+
+	mkdirp(t, "/_test/truncate")
+
+	err := client.Truncate("/_test/truncate", 100)
+	assertPathError(t, err, "truncate", "/_test/truncate", os.ErrNotExist)
+}
+
+func TestTruncateWithoutPermission(t *testing.T) {
+	client := getClient(t)
+	client2 := getClientForUser(t, "gohdfs2")
+
+	baleet(t, "/_test/truncate/5.txt")
+	mkdirp(t, "/_test/truncate")
+
+	f, err := client.Create("/_test/truncate/5.txt")
+	require.NoError(t, err)
+
+	n, err := f.Write([]byte("barbar"))
+	assert.Equal(t, 6, n)
+	require.NoError(t, err)
+
+	assertClose(t, f)
+
+	err = client2.Truncate("/_test/truncate/5.txt", 1)
+	assertPathError(t, err, "truncate", "/_test/truncate/5.txt", os.ErrPermission)
+
+	stat, err := client.Stat("/_test/truncate/5.txt")
+	require.NoError(t, err)
+	assert.EqualValues(t, 6, stat.Size())
+}


### PR DESCRIPTION
This PR is to provide `truncate` feature. About the test:
1. Cloudera's package uses Hadoop-2.6, which does not support `truncate` yet (till Hadoop-2.7, `truncate` is supported).
2. `truncate` takes some time to be effective, and now a time delay (3 seconds, longer maybe safer) is added to the test. Not sure if we can find another better way for this, as the users may need to be aware this delay as well when `truncate` is used.