### PR TITLE
Change Block Checksum Algorithm to CRC32C

### DIFF
--- a/rpc/block_writer.go
+++ b/rpc/block_writer.go
@@ -211,7 +211,7 @@ func (bw *BlockWriter) writeBlockWriteRequest(w io.Writer) error {
 		MaxBytesRcvd:          proto.Uint64(uint64(bw.offset)),
 		LatestGenerationStamp: proto.Uint64(uint64(bw.generationTimestamp())),
 		RequestedChecksum: &hdfs.ChecksumProto{
-			Type:             hdfs.ChecksumTypeProto_CHECKSUM_CRC32.Enum(),
+			Type:             hdfs.ChecksumTypeProto_CHECKSUM_CRC32C.Enum(),
 			BytesPerChecksum: proto.Uint32(outboundChunkSize),
 		},
 	}


### PR DESCRIPTION
This is to update the block checksum algorithm to the one used by recent Hadoop distributions.

**http://stackoverflow.com/questions/26429360/crc32-vs-crc32c**

