### PR TITLE
support for multiple namenodes with failover

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,13 @@ type Client struct {
 	defaults *hdfs.FsServerDefaultsProto
 }
 
+// ClientOptions represents the configurable options for a client.
+type ClientOptions struct {
+	Addresses []string
+	Namenode  *rpc.NamenodeConnection
+	User      string
+}
+
 // Username returns the value of HADOOP_USER_NAME in the environment, or
 // the current system user if it is not set.
 func Username() (string, error) {
@@ -30,53 +37,79 @@ func Username() (string, error) {
 	return currentUser.Username, nil
 }
 
+// NewClient returns a connected Client for the given options, or an error if
+// the client could not be created.
+func NewClient(options ClientOptions) (*Client, error) {
+	var err error
+
+	if options.User == "" {
+		options.User, err = Username()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if options.Addresses == nil || len(options.Addresses) == 0 {
+		options.Addresses, err = getNameNodeFromConf()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if options.Namenode == nil {
+		options.Namenode, err = rpc.NewNamenodeConnectionWithOptions(
+			rpc.NamenodeConnectionOptions{
+				Addresses: options.Addresses,
+				User:      options.User,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &Client{namenode: options.Namenode}, nil
+}
+
 // New returns a connected Client, or an error if it can't connect. The user
 // will be the user the code is running under. If address is an empty string
 // it will try and get the namenode address from the hadoop configuration
 // files.
 func New(address string) (*Client, error) {
-	username, err := Username()
-	if err != nil {
-		return nil, err
+	options := ClientOptions{}
+
+	if address != "" {
+		options.Addresses = []string{address}
 	}
 
-	if address == "" {
-		var nnErr error
-		address, nnErr = getNameNodeFromConf()
-		if nnErr != nil {
-			return nil, nnErr
-		}
-	}
-
-	return NewForUser(address, username)
+	return NewClient(options)
 }
 
-// getNameNodeFromConf return a datanode from the system hadoop configuration
-func getNameNodeFromConf() (string, error) {
+// getNameNodeFromConf returns namenodes from the system Hadoop configuration.
+func getNameNodeFromConf() ([]string, error) {
 	hadoopConf := LoadHadoopConf("")
 
 	namenodes, nnErr := hadoopConf.Namenodes()
 	if nnErr != nil {
-		return "", nnErr
+		return nil, nnErr
 	}
-	return namenodes[0], nil
+	return namenodes, nil
 }
 
 // NewForUser returns a connected Client with the user specified, or an error if
 // it can't connect.
 func NewForUser(address string, user string) (*Client, error) {
-	namenode, err := rpc.NewNamenodeConnection(address, user)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Client{namenode: namenode}, nil
+	return NewClient(ClientOptions{
+		Addresses: []string{address},
+		User:      user,
+	})
 }
 
 // NewForConnection returns Client with the specified, underlying rpc.NamenodeConnection.
 // You can use rpc.WrapNamenodeConnection to wrap your own net.Conn.
 func NewForConnection(namenode *rpc.NamenodeConnection) *Client {
-	return &Client{namenode: namenode}
+	client, _ := NewClient(ClientOptions{Namenode: namenode})
+	return client
 }
 
 // ReadFile reads the file named by filename and returns the contents.

--- a/client_test.go
+++ b/client_test.go
@@ -75,6 +75,22 @@ func assertPathError(t *testing.T, err error, op, path string, wrappedErr error)
 	require.Equal(t, expected, err)
 }
 
+func TestNewWithMultipleNodes(t *testing.T) {
+	nn := os.Getenv("HADOOP_NAMENODE")
+	if nn == "" {
+		t.Fatal("HADOOP_NAMENODE not set")
+	}
+	_, err := NewClient(ClientOptions{
+		Addresses: []string{"localhost:80", nn},
+	})
+	assert.Nil(t, err)
+}
+
+func TestNewWithFailingNode(t *testing.T) {
+	_, err := New("localhost:80")
+	assert.NotNil(t, err)
+}
+
 func TestReadFile(t *testing.T) {
 	client := getClient(t)
 

--- a/rpc/namenode.go
+++ b/rpc/namenode.go
@@ -117,6 +117,7 @@ func (c *NamenodeConnection) resolveConnection() error {
 		return nil
 	}
 
+	var err error
 	for _, host := range c.hostList {
 		if c.host == host {
 			continue
@@ -126,7 +127,6 @@ func (c *NamenodeConnection) resolveConnection() error {
 			continue
 		}
 
-		var err error
 		c.host = host
 		c.conn, err = net.DialTimeout("tcp", host.address, connectTimeout)
 		if err != nil {
@@ -144,7 +144,7 @@ func (c *NamenodeConnection) resolveConnection() error {
 	}
 
 	if c.conn == nil {
-		return fmt.Errorf("No available namenodes")
+		return fmt.Errorf("no available namenodes: %s", err.Error())
 	}
 
 	return nil

--- a/rpc/namenode.go
+++ b/rpc/namenode.go
@@ -31,8 +31,8 @@ type NamenodeConnection struct {
 	currentRequestID int
 	user             string
 	conn             net.Conn
-	host             *host
-	hostList         []*host
+	host             *namenodeHost
+	hostList         []*namenodeHost
 	reqLock          sync.Mutex
 }
 
@@ -67,7 +67,7 @@ func (err *NamenodeError) Error() string {
 	return s
 }
 
-type host struct {
+type namenodeHost struct {
 	address     string
 	lastFailure time.Time
 }
@@ -88,9 +88,9 @@ func NewNamenodeConnection(address string, user string) (*NamenodeConnection, er
 // the given options and performs an initial handshake.
 func NewNamenodeConnectionWithOptions(options NamenodeConnectionOptions) (*NamenodeConnection, error) {
 	// Build the list of hosts to be used for failover.
-	hostList := make([]*host, len(options.Addresses))
+	hostList := make([]*namenodeHost, len(options.Addresses))
 	for i, addr := range options.Addresses {
-		hostList[i] = &host{address: addr}
+		hostList[i] = &namenodeHost{address: addr}
 	}
 
 	// The ClientID is reused here both in the RPC headers (which requires a

--- a/rpc/namenode.go
+++ b/rpc/namenode.go
@@ -14,12 +14,13 @@ import (
 )
 
 const (
-	rpcVersion           = 0x09
-	serviceClass         = 0x0
-	authProtocol         = 0x0
-	protocolClass        = "org.apache.hadoop.hdfs.protocol.ClientProtocol"
-	protocolClassVersion = 1
-	handshakeCallID      = -3
+	rpcVersion            = 0x09
+	serviceClass          = 0x0
+	authProtocol          = 0x0
+	protocolClass         = "org.apache.hadoop.hdfs.protocol.ClientProtocol"
+	protocolClassVersion  = 1
+	handshakeCallID       = -3
+	standbyExceptionClass = "org.apache.hadoop.ipc.StandbyException"
 )
 
 const backoffDuration = time.Second * 5
@@ -188,7 +189,8 @@ R:
 	err = c.readResponse(method, resp)
 	if err != nil {
 		if nerr, ok := err.(*NamenodeError); ok {
-			if nerr.Exception != "org.apache.hadoop.ipc.StandbyException" {
+			// if it's not a standby exception, we won't retry
+			if nerr.Exception != standbyExceptionClass {
 				return err
 			}
 		}


### PR DESCRIPTION
Hello! Here's a basic implementation for multiple namenode support.

- If a request results in a non-`NamenodeError` (i.e. EOF) or `StandbyException`, the client will close the current connection, try to establish a new connection with another host, and retry the request.
- The failing host will be marked as down and a connection attempt won't be made for at least 5 seconds (not configurable at the moment, but could be).
- If all hosts were unreachable or in standby, the client request will result in a `"No available namenodes"` error.

I realise there isn't much in terms of testing for this behaviour - would be happy to hear some suggestions for how this could be done.