### PR TITLE
Set timeout for reads and write to the data nodes.

### DIFF
--- a/rpc/block_reader.go
+++ b/rpc/block_reader.go
@@ -78,6 +78,7 @@ func (br *BlockReader) Read(b []byte) (int, error) {
 		br.offset += int64(n)
 		if err != nil && err != io.EOF {
 			br.stream = nil
+			br.conn.Close()
 			br.datanodes.recordFailure(err)
 			if n > 0 {
 				return n, nil
@@ -116,6 +117,7 @@ func (br *BlockReader) connectNext() error {
 	if err != nil {
 		return err
 	}
+	conn.SetDeadline(datanodeTimeout)
 
 	err = br.writeBlockReadRequest(conn)
 	if err != nil {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -24,7 +24,7 @@ const (
 var (
 	connectTimeout  = 1 * time.Second
 	namenodeTimeout = 3 * time.Second
-	datanodeTimeout = 3 * time.Second
+	datanodeTimeout = 25 * time.Second
 )
 
 // Used for client ID generation, below.


### PR DESCRIPTION
We are facing an issue where the read process gets stuck waiting on the read to complete. The underlying connection was closed from the server side, but the client was still expecting to read something, and hence blocked. Adding timeout to avoid getting stuck.