### PR TITLE
Fix alignment in blockWriteStream.

### DIFF
--- a/rpc/block_write_stream.go
+++ b/rpc/block_write_stream.go
@@ -173,7 +173,7 @@ func (s *blockWriteStream) makePacket() outboundPacket {
 	// gets unhappy unless we first align to a chunk boundary with a small packet.
 	// Otherwise it yells at us with "a partial chunk must be sent in an
 	// individual packet" or just complains about a corrupted block.
-	alignment := outboundChunkSize - (int(s.offset) % outboundChunkSize)
+	alignment := (outboundChunkSize - (int(s.offset) % outboundChunkSize)) % outboundChunkSize
 	if alignment > 0 && alignment < packetLength {
 		packetLength = alignment
 	}


### PR DESCRIPTION
There was a bug that caused packet size to always equal chunkSize (512 bytes). I discovered this when debugging performance with `perf trace`.

Fixed this by taking `alignment = (chunkSize - (offset % chunkSize)) % chunkSize`, which will be 0 when the offset is aligned.

Added a simple test to verify this.