### PR TITLE
Fix FileReader ReadAt errors

### DIFF
--- a/file_reader.go
+++ b/file_reader.go
@@ -192,12 +192,16 @@ func (f *FileReader) ReadAt(b []byte, off int64) (int, error) {
 		return 0, io.ErrClosedPipe
 	}
 
+	if off < 0 {
+		return 0, &os.PathError{"readat", f.name, errors.New("negative offset")}
+	}
+
 	_, err := f.Seek(off, 0)
 	if err != nil {
 		return 0, err
 	}
 
-	return io.ReadFull(f, b)
+	return f.Read(b)
 }
 
 // Readdir reads the contents of the directory associated with file and returns


### PR DESCRIPTION
Using `io.ReadFull()` changes the error message to `io.ErrUnexpectedEOF` instead of the expected `io.EOF`. This fixes the behavior to be handled like `os.FIle` https://golang.org/pkg/os/#File.ReadAt