### PR TITLE
Fix rpc.resolveConnection() deadlock

### DIFF
--- a/rpc/namenode.go
+++ b/rpc/namenode.go
@@ -151,10 +151,6 @@ func (c *NamenodeConnection) resolveConnection() error {
 	}
 
 	for _, host := range c.hostList {
-		if c.host == host {
-			continue
-		}
-
 		if host.lastErrorAt.After(time.Now().Add(-backoffDuration)) {
 			continue
 		}

--- a/rpc/namenode_test.go
+++ b/rpc/namenode_test.go
@@ -1,0 +1,19 @@
+package rpc
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamenodeConnection_resolveConnection(t *testing.T) {
+	conn := getNamenode(t)
+	conn.markFailure(io.EOF)
+
+	assert.Error(t, conn.resolveConnection())
+	conn.host.lastErrorAt = time.Now().Add(-backoffDuration)
+	assert.NoError(t, conn.resolveConnection())
+	cachedNamenode = nil
+}


### PR DESCRIPTION
If c.hostList only consists of the single namenode connection this will deadlock.