### PR TITLE
use HostName instead of IpAddr for multi-homed HDFS

### DIFF
--- a/rpc/checksum_reader.go
+++ b/rpc/checksum_reader.go
@@ -29,7 +29,7 @@ func NewChecksumReader(block *hdfs.LocatedBlockProto) *ChecksumReader {
 	datanodes := make([]string, len(locs))
 	for i, loc := range locs {
 		dn := loc.GetId()
-		datanodes[i] = fmt.Sprintf("%s:%d", dn.GetIpAddr(), dn.GetXferPort())
+		datanodes[i] = fmt.Sprintf("%s:%d", dn.GetHostName(), dn.GetXferPort())
 	}
 
 	return &ChecksumReader{

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -156,5 +156,5 @@ func readBlockOpResponse(r io.Reader) (*hdfs.BlockOpResponseProto, error) {
 
 func getDatanodeAddress(datanode *hdfs.DatanodeInfoProto) string {
 	id := datanode.GetId()
-	return fmt.Sprintf("%s:%d", id.GetIpAddr(), id.GetXferPort())
+	return fmt.Sprintf("%s:%d", id.GetHostName(), id.GetXferPort())
 }


### PR DESCRIPTION
In multi-homed HDFS setups the IP address is not accessible from all nodes and the hostname should be used anyway. It's not the client libraries job to workaround broken DNS/resolver setups.