### PR TITLE
the result of filepath.Join doesn't work if the client runs on Windows

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -42,7 +42,7 @@ func (c *Client) walk(path string, walkFn filepath.WalkFunc) error {
 
 	sort.Strings(names)
 	for _, name := range names {
-		err = c.walk(filepath.Join(path, name), walkFn)
+		err = c.walk(filepath.ToSlash(filepath.Join(path, name)), walkFn)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
the result of filepath.Join doesn't work if the client runs on Windows while the server runs on Linux