### PR TITLE
Global rpc.ConnectTimeout set via client options.

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
+	"time"
 
 	hdfs "github.com/colinmarc/hdfs/protocol/hadoop_hdfs"
 	"github.com/colinmarc/hdfs/rpc"
@@ -18,9 +19,10 @@ type Client struct {
 
 // ClientOptions represents the configurable options for a client.
 type ClientOptions struct {
-	Addresses []string
-	Namenode  *rpc.NamenodeConnection
-	User      string
+	Addresses      []string
+	Namenode       *rpc.NamenodeConnection
+	User           string
+	ConnectTimeout time.Duration
 }
 
 // Username returns the value of HADOOP_USER_NAME in the environment, or
@@ -66,6 +68,10 @@ func NewClient(options ClientOptions) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if options.ConnectTimeout > 0 {
+		rpc.ConnectTimeout = options.ConnectTimeout
 	}
 
 	return &Client{namenode: options.Namenode}, nil

--- a/rpc/block_reader.go
+++ b/rpc/block_reader.go
@@ -112,7 +112,7 @@ func (br *BlockReader) Close() error {
 func (br *BlockReader) connectNext() error {
 	address := br.datanodes.next()
 
-	conn, err := net.DialTimeout("tcp", address, connectTimeout)
+	conn, err := net.DialTimeout("tcp", address, ConnectTimeout)
 	if err != nil {
 		return err
 	}

--- a/rpc/block_write_stream.go
+++ b/rpc/block_write_stream.go
@@ -244,7 +244,7 @@ func (s *blockWriteStream) ackPackets() {
 	// Once we've seen an error, just keep reading packets off the channel (but
 	// not off the socket) until the writing thread figures it out. If we don't,
 	// the upstream thread could deadlock waiting for the channel to have space.
-	for _ = range s.packets {
+	for range s.packets {
 	}
 }
 

--- a/rpc/block_writer.go
+++ b/rpc/block_writer.go
@@ -119,7 +119,7 @@ func (bw *BlockWriter) Close() error {
 func (bw *BlockWriter) connectNext() error {
 	address := getDatanodeAddress(bw.currentPipeline()[0])
 
-	conn, err := net.DialTimeout("tcp", address, connectTimeout)
+	conn, err := net.DialTimeout("tcp", address, ConnectTimeout)
 	if err != nil {
 		return err
 	}

--- a/rpc/checksum_reader.go
+++ b/rpc/checksum_reader.go
@@ -60,7 +60,7 @@ func (cr *ChecksumReader) ReadChecksum() ([]byte, error) {
 }
 
 func (cr *ChecksumReader) readChecksum(address string) ([]byte, error) {
-	conn, err := net.DialTimeout("tcp", address, connectTimeout)
+	conn, err := net.DialTimeout("tcp", address, ConnectTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/namenode.go
+++ b/rpc/namenode.go
@@ -156,7 +156,7 @@ func (c *NamenodeConnection) resolveConnection() error {
 		}
 
 		c.host = host
-		c.conn, err = net.DialTimeout("tcp", host.address, connectTimeout)
+		c.conn, err = net.DialTimeout("tcp", host.address, ConnectTimeout)
 		if err != nil {
 			c.markFailure(err)
 			continue

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	connectTimeout  = 1 * time.Second
+	ConnectTimeout  = 1 * time.Second
 	namenodeTimeout = 3 * time.Second
 	datanodeTimeout = 3 * time.Second
 )


### PR DESCRIPTION
This addresses the lack of a configurable connect timeout (see https://github.com/colinmarc/hdfs/issues/76).