### PR TITLE
Create RPC options, pass them through from the client

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -63,6 +63,20 @@ func LoadHadoopConf(path string) HadoopConf {
 	return hadoopConf
 }
 
+// UseDatanodeHostname returns whether or not the option
+// dfs.client.use.datanode.hostname is enabled -- thereby using the hostname of
+// datanodes as opposed to IP addressses
+func (conf HadoopConf) UseDatanodeHostname() bool {
+	v, ok := conf["dfs.client.use.datanode.hostname"]
+	if !ok {
+		return false
+	}
+	if v == "true" {
+		return true
+	}
+	return false
+}
+
 // Namenodes returns the namenode hosts present in the configuration. The
 // returned slice will be sorted and deduped.
 func (conf HadoopConf) Namenodes() ([]string, error) {

--- a/file_reader.go
+++ b/file_reader.go
@@ -84,7 +84,7 @@ func (f *FileReader) Checksum() ([]byte, error) {
 	totalLength := 0
 	checksum := md5.New()
 	for _, block := range f.blocks {
-		cr := rpc.NewChecksumReader(block)
+		cr := rpc.NewChecksumReader(block, f.client.RPCOptions())
 
 		blockChecksum, err := cr.ReadChecksum()
 		if err != nil {
@@ -378,7 +378,7 @@ func (f *FileReader) getNewBlockReader() error {
 		end := start + block.GetB().GetNumBytes()
 
 		if start <= off && off < end {
-			br := rpc.NewBlockReader(block, int64(off-start), f.client.namenode.ClientName())
+			br := rpc.NewBlockReader(block, int64(off-start), f.client.RPCOptions())
 
 			f.blockReader = br
 			return nil

--- a/file_writer.go
+++ b/file_writer.go
@@ -127,7 +127,7 @@ func (c *Client) Append(name string) (*FileWriter, error) {
 		return f, nil
 	}
 	f.block = blocks[len(blocks)-1]
-	f.blockWriter = rpc.NewBlockWriter(f.block, c.namenode, f.blockSize)
+	f.blockWriter = rpc.NewBlockWriter(f.block, c.namenode, f.blockSize, c.RPCOptions())
 	return f, nil
 }
 
@@ -254,6 +254,6 @@ func (f *FileWriter) startNewBlock() error {
 	}
 
 	f.block = addBlockResp.GetBlock()
-	f.blockWriter = rpc.NewBlockWriter(f.block, f.client.namenode, f.blockSize)
+	f.blockWriter = rpc.NewBlockWriter(f.block, f.client.namenode, f.blockSize, f.client.RPCOptions())
 	return nil
 }

--- a/rpc/block_reader.go
+++ b/rpc/block_reader.go
@@ -16,30 +16,30 @@ import (
 // reading from multiple datanodes, in order to be robust to connection
 // failures, timeouts, and other shenanigans.
 type BlockReader struct {
-	clientName string
-	block      *hdfs.LocatedBlockProto
-	datanodes  *datanodeFailover
-	stream     *blockReadStream
-	conn       net.Conn
-	offset     int64
-	closed     bool
+	opts      Options
+	block     *hdfs.LocatedBlockProto
+	datanodes *datanodeFailover
+	stream    *blockReadStream
+	conn      net.Conn
+	offset    int64
+	closed    bool
 }
 
 // NewBlockReader returns a new BlockReader, given the block information and
 // security token from the namenode. It will connect (lazily) to one of the
 // provided datanode locations based on which datanodes have seen failures.
-func NewBlockReader(block *hdfs.LocatedBlockProto, offset int64, clientName string) *BlockReader {
+func NewBlockReader(block *hdfs.LocatedBlockProto, offset int64, opts Options) *BlockReader {
 	locs := block.GetLocs()
 	datanodes := make([]string, len(locs))
 	for i, loc := range locs {
-		datanodes[i] = getDatanodeAddress(loc)
+		datanodes[i] = getDatanodeAddress(loc, opts.UseDatanodeHostname)
 	}
 
 	return &BlockReader{
-		clientName: clientName,
-		block:      block,
-		datanodes:  newDatanodeFailover(datanodes),
-		offset:     offset,
+		opts:      opts,
+		block:     block,
+		datanodes: newDatanodeFailover(datanodes),
+		offset:    offset,
 	}
 }
 
@@ -182,7 +182,7 @@ func (br *BlockReader) writeBlockReadRequest(w io.Writer) error {
 				Block: br.block.GetB(),
 				Token: br.block.GetBlockToken(),
 			},
-			ClientName: proto.String(br.clientName),
+			ClientName: proto.String(br.opts.ClientName),
 		},
 		Offset: proto.Uint64(uint64(br.offset)),
 		Len:    proto.Uint64(needed),

--- a/rpc/checksum_reader.go
+++ b/rpc/checksum_reader.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 
@@ -28,12 +27,7 @@ func NewChecksumReader(block *hdfs.LocatedBlockProto, opts Options) *ChecksumRea
 	locs := block.GetLocs()
 	datanodes := make([]string, len(locs))
 	for i, loc := range locs {
-		dn := loc.GetId()
-		host := dn.GetIpAddr()
-		if opts.UseDatanodeHostname {
-			host = dn.GetHostName()
-		}
-		datanodes[i] = fmt.Sprintf("%s:%d", host, dn.GetXferPort())
+		datanodes[i] = getDatanodeAddress(loc, opts.UseDatanodeHostname)
 	}
 
 	return &ChecksumReader{

--- a/rpc/checksum_reader.go
+++ b/rpc/checksum_reader.go
@@ -24,12 +24,16 @@ type ChecksumReader struct {
 }
 
 // NewChecksumReader creates a new ChecksumReader for the given block.
-func NewChecksumReader(block *hdfs.LocatedBlockProto) *ChecksumReader {
+func NewChecksumReader(block *hdfs.LocatedBlockProto, opts Options) *ChecksumReader {
 	locs := block.GetLocs()
 	datanodes := make([]string, len(locs))
 	for i, loc := range locs {
 		dn := loc.GetId()
-		datanodes[i] = fmt.Sprintf("%s:%d", dn.GetHostName(), dn.GetXferPort())
+		host := dn.GetIpAddr()
+		if opts.UseDatanodeHostname {
+			host = dn.GetHostName()
+		}
+		datanodes[i] = fmt.Sprintf("%s:%d", host, dn.GetXferPort())
 	}
 
 	return &ChecksumReader{

--- a/rpc/options.go
+++ b/rpc/options.go
@@ -1,0 +1,8 @@
+package rpc
+
+// Options is a collection of the different parameters availble
+// to RPC calls.
+type Options struct {
+	ClientName          string
+	UseDatanodeHostname bool
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -154,7 +154,11 @@ func readBlockOpResponse(r io.Reader) (*hdfs.BlockOpResponseProto, error) {
 	return resp, err
 }
 
-func getDatanodeAddress(datanode *hdfs.DatanodeInfoProto) string {
+func getDatanodeAddress(datanode *hdfs.DatanodeInfoProto, useHostname bool) string {
 	id := datanode.GetId()
-	return fmt.Sprintf("%s:%d", id.GetHostName(), id.GetXferPort())
+	host := id.GetIpAddr()
+	if useHostname {
+		host = id.GetHostName()
+	}
+	return fmt.Sprintf("%s:%d", host, id.GetXferPort())
 }

--- a/testdata/conf/hdfs-site.xml
+++ b/testdata/conf/hdfs-site.xml
@@ -35,4 +35,8 @@
         <name>dfs.namenode.rpc-address.tests.nn2</name>
         <value>namenode2:8020</value>
     </property>
+    <property>
+        <name>dfs.client.use.datanode.hostname</name>
+        <value>true</value>
+    </property>
 </configuration>


### PR DESCRIPTION
This change adds the ability to pass client options through to the underlying RPC calls. This is useful for `dfs.client.*` options from hdfs-site.xml, including timeouts and the like.

It seemed right to pass in an RPC options struct, so I created one, and subsumed related parameters (eg, `clientName`) where it made sense. This provides a nice general framework for other such connection options (usually pertaining to connections made to datanodes).

Adds support for `dfs.client.use.datanode.hostname`, which fixes #118, and functionally reverts `a79e6ee`, while respecting `hdfs-site.xml` for those that use this functionality.
