### PR TITLE
Add an option for UseDatanodeHostname based on dfs.client.use.datanode.hostname

### DIFF
--- a/file_reader.go
+++ b/file_reader.go
@@ -378,9 +378,13 @@ func (f *FileReader) getNewBlockReader() error {
 		end := start + block.GetB().GetNumBytes()
 
 		if start <= off && off < end {
-			br := rpc.NewBlockReader(block, int64(off-start), f.client.namenode.ClientName())
+			f.blockReader = &rpc.BlockReader{
+				ClientName:          f.client.namenode.ClientName(),
+				Block:               block,
+				Offset:              int64(off - start),
+				UseDatanodeHostname: f.client.options.UseDatanodeHostname,
+			}
 
-			f.blockReader = br
 			return nil
 		}
 	}

--- a/rpc/checksum_reader.go
+++ b/rpc/checksum_reader.go
@@ -29,7 +29,7 @@ func NewChecksumReader(block *hdfs.LocatedBlockProto) *ChecksumReader {
 	datanodes := make([]string, len(locs))
 	for i, loc := range locs {
 		dn := loc.GetId()
-		datanodes[i] = fmt.Sprintf("%s:%d", dn.GetHostName(), dn.GetXferPort())
+		datanodes[i] = fmt.Sprintf("%s:%d", dn.GetIpAddr(), dn.GetXferPort())
 	}
 
 	return &ChecksumReader{

--- a/rpc/checksum_reader.go
+++ b/rpc/checksum_reader.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 
@@ -16,30 +15,40 @@ import (
 // individual blocks. It abstracts over reading from multiple datanodes, in
 // order to be robust to failures.
 type ChecksumReader struct {
-	block     *hdfs.LocatedBlockProto
-	datanodes *datanodeFailover
+	// Block is the block location provided by the namenode.
+	Block *hdfs.LocatedBlockProto
+	// UseDatanodeHostname specifies whether the datanodes should be connected to
+	// via their hostnames (if true) or IP addresses (if false).
+	UseDatanodeHostname bool
 
-	conn   net.Conn
-	reader *bufio.Reader
+	datanodes *datanodeFailover
+	conn      net.Conn
+	reader    *bufio.Reader
 }
 
 // NewChecksumReader creates a new ChecksumReader for the given block.
+//
+// Deprecated: this method does not do any required initialization, and does
+// not allow you to set fields such as UseDatanodeHostname.
 func NewChecksumReader(block *hdfs.LocatedBlockProto) *ChecksumReader {
-	locs := block.GetLocs()
-	datanodes := make([]string, len(locs))
-	for i, loc := range locs {
-		dn := loc.GetId()
-		datanodes[i] = fmt.Sprintf("%s:%d", dn.GetIpAddr(), dn.GetXferPort())
-	}
-
 	return &ChecksumReader{
-		block:     block,
-		datanodes: newDatanodeFailover(datanodes),
+		Block: block,
 	}
 }
 
 // ReadChecksum returns the checksum of the block.
 func (cr *ChecksumReader) ReadChecksum() ([]byte, error) {
+	if cr.datanodes == nil {
+		locs := cr.Block.GetLocs()
+		datanodes := make([]string, len(locs))
+		for i, loc := range locs {
+			dn := loc.GetId()
+			datanodes[i] = getDatanodeAddress(dn, cr.UseDatanodeHostname)
+		}
+
+		cr.datanodes = newDatanodeFailover(datanodes)
+	}
+
 	for cr.datanodes.numRemaining() > 0 {
 		address := cr.datanodes.next()
 		checksum, err := cr.readChecksum(address)
@@ -91,7 +100,7 @@ func (cr *ChecksumReader) readChecksum(address string) ([]byte, error) {
 func (cr *ChecksumReader) writeBlockChecksumRequest() error {
 	header := []byte{0x00, dataTransferVersion, checksumBlockOp}
 
-	op := newChecksumBlockOp(cr.block)
+	op := newChecksumBlockOp(cr.Block)
 	opBytes, err := makePrefixedMessage(op)
 	if err != nil {
 		return err

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -156,5 +156,5 @@ func readBlockOpResponse(r io.Reader) (*hdfs.BlockOpResponseProto, error) {
 
 func getDatanodeAddress(datanode *hdfs.DatanodeInfoProto) string {
 	id := datanode.GetId()
-	return fmt.Sprintf("%s:%d", id.GetHostName(), id.GetXferPort())
+	return fmt.Sprintf("%s:%d", id.GetIpAddr(), id.GetXferPort())
 }

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -154,7 +154,13 @@ func readBlockOpResponse(r io.Reader) (*hdfs.BlockOpResponseProto, error) {
 	return resp, err
 }
 
-func getDatanodeAddress(datanode *hdfs.DatanodeInfoProto) string {
-	id := datanode.GetId()
-	return fmt.Sprintf("%s:%d", id.GetIpAddr(), id.GetXferPort())
+func getDatanodeAddress(datanode *hdfs.DatanodeIDProto, useHostname bool) string {
+	var host string
+	if useHostname {
+		host = datanode.GetHostName()
+	} else {
+		host = datanode.GetIpAddr()
+	}
+
+	return fmt.Sprintf("%s:%d", host, datanode.GetXferPort())
 }


### PR DESCRIPTION
Since #123, we've been hardcoding hostname rather than IP address, but it's better to use the default from HDFS (`false`, or ip address) and make it configurable. So this reverts #123. It fixes #118, and obviates #137.

This required some messy-looking but ultimately minor refactoring of `rpc.BlockWriter` and `rpc.BlockReader`.