### PR TITLE
Add mechanisms for specifying connect timeouts and read/write deadlines

### DIFF
--- a/cmd/hdfs/main.go
+++ b/cmd/hdfs/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
+	"time"
 
 	"github.com/colinmarc/hdfs"
 	"github.com/pborman/getopt"
@@ -198,6 +200,16 @@ func getClient(namenode string) (*hdfs.Client, error) {
 			return nil, fmt.Errorf("Couldn't determine user: %s", err)
 		}
 	}
+
+	// Set some basic defaults.
+	dialFunc := (&net.Dialer{
+		Timeout:   5 * time.Second,
+		KeepAlive: 5 * time.Second,
+		DualStack: true,
+	}).DialContext
+
+	options.NamenodeDialFunc = dialFunc
+	options.DatanodeDialFunc = dialFunc
 
 	c, err := hdfs.NewClient(options)
 	if err != nil {

--- a/file_reader.go
+++ b/file_reader.go
@@ -75,10 +75,10 @@ func (f *FileReader) Checksum() ([]byte, error) {
 		}
 	}
 
-	// The way the hadoop code calculates this, it writes all the checksums out to
-	// a byte array, which is automatically padded with zeroes out to the next
-	// power of 2 (with a minimum of 32)... and then takes the MD5 of that array,
-	// including the zeroes. This is pretty shady business, but we want to track
+	// Hadoop calculates this by writing the checksums out to a byte array, which
+	// is automatically padded with zeroes out to the next  power of 2
+	// (with a minimum of 32)... and then takes the MD5 of that array, including
+	// the zeroes. This is pretty shady business, but we want to track
 	// the 'hadoop fs -checksum' behavior if possible.
 	paddedLength := 32
 	totalLength := 0
@@ -87,6 +87,7 @@ func (f *FileReader) Checksum() ([]byte, error) {
 		cr := &rpc.ChecksumReader{
 			Block:               block,
 			UseDatanodeHostname: f.client.options.UseDatanodeHostname,
+			DialFunc:            f.client.options.DatanodeDialFunc,
 		}
 
 		blockChecksum, err := cr.ReadChecksum()
@@ -386,6 +387,7 @@ func (f *FileReader) getNewBlockReader() error {
 				Block:               block,
 				Offset:              int64(off - start),
 				UseDatanodeHostname: f.client.options.UseDatanodeHostname,
+				DialFunc:            f.client.options.DatanodeDialFunc,
 			}
 
 			return nil

--- a/file_reader_test.go
+++ b/file_reader_test.go
@@ -296,3 +296,55 @@ func TestFileChecksum(t *testing.T) {
 
 	assert.EqualValues(t, testChecksum, hex.EncodeToString(checksum))
 }
+
+func TestFileReadDeadline(t *testing.T) {
+	client := getClient(t)
+
+	file, err := client.Open("/_test/foo.txt")
+	require.NoError(t, err)
+
+	file.SetDeadline(time.Now().Add(100 * time.Millisecond))
+	_, err = file.Read([]byte{0, 0})
+	assert.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+	_, err = file.Read([]byte{0, 0})
+	assert.NotNil(t, err)
+}
+
+func TestFileReadDeadlineBefore(t *testing.T) {
+	client := getClient(t)
+
+	file, err := client.Open("/_test/foo.txt")
+	require.NoError(t, err)
+
+	file.SetDeadline(time.Now())
+	_, err = file.Read([]byte{0, 0})
+	assert.NotNil(t, err)
+}
+
+func TestFileChecksumDeadline(t *testing.T) {
+	client := getClient(t)
+
+	file, err := client.Open("/_test/foo.txt")
+	require.NoError(t, err)
+
+	file.SetDeadline(time.Now().Add(100 * time.Millisecond))
+	_, err = file.Checksum()
+	assert.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+	_, err = file.Checksum()
+	assert.NotNil(t, err)
+}
+
+func TestFileChecksumDeadlineBefore(t *testing.T) {
+	client := getClient(t)
+
+	file, err := client.Open("/_test/foo.txt")
+	require.NoError(t, err)
+
+	file.SetDeadline(time.Now())
+	_, err = file.Checksum()
+	assert.NotNil(t, err)
+}

--- a/file_writer.go
+++ b/file_writer.go
@@ -140,6 +140,7 @@ func (c *Client) Append(name string) (*FileWriter, error) {
 		Offset:              int64(lastBlock.B.GetNumBytes()),
 		Append:              true,
 		UseDatanodeHostname: f.client.options.UseDatanodeHostname,
+		DialFunc:            f.client.options.DatanodeDialFunc,
 	}
 
 	return f, nil
@@ -271,6 +272,7 @@ func (f *FileWriter) startNewBlock() error {
 		Block:               addBlockResp.GetBlock(),
 		BlockSize:           f.blockSize,
 		UseDatanodeHostname: f.client.options.UseDatanodeHostname,
+		DialFunc:            f.client.options.DatanodeDialFunc,
 	}
 
 	return nil

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -21,12 +21,6 @@ const (
 	checksumBlockOp     = 0x55
 )
 
-var (
-	connectTimeout  = 1 * time.Second
-	namenodeTimeout = 3 * time.Second
-	datanodeTimeout = 3 * time.Second
-)
-
 // Used for client ID generation, below.
 const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 


### PR DESCRIPTION
Connect timeouts are enabled by allowing users to specify a `DialFunc`. Fixes #70, #76, #130.