### PR TITLE
fix hadoop_common proto building and syntax proto warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ RELEASE_NAME = gohdfs-$(TRAVIS_TAG)-$(ARCH)
 all: hdfs
 
 %.pb.go: $(HADOOP_HDFS_PROTOS) $(HADOOP_COMMON_PROTOS)
-	protoc --go_out='$(PROTO_MAPPING):internal/protocol/hadoop_common' -Iinternal/protocol/hadoop_common -Iinternal/protocol/hadoop_hdfs $(HADOOP_COMMON_PROTOS)
+	protoc --go_out='internal/protocol/hadoop_common' -Iinternal/protocol/hadoop_common -Iinternal/protocol/hadoop_hdfs $(HADOOP_COMMON_PROTOS)
 	protoc --go_out='$(PROTO_MAPPING):internal/protocol/hadoop_hdfs' -Iinternal/protocol/hadoop_common -Iinternal/protocol/hadoop_hdfs $(HADOOP_HDFS_PROTOS)
 
 clean-protos:

--- a/internal/protocol/hadoop_common/GenericRefreshProtocol.proto
+++ b/internal/protocol/hadoop_common/GenericRefreshProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/GetUserMappingsProtocol.proto
+++ b/internal/protocol/hadoop_common/GetUserMappingsProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/HAServiceProtocol.proto
+++ b/internal/protocol/hadoop_common/HAServiceProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/IpcConnectionContext.proto
+++ b/internal/protocol/hadoop_common/IpcConnectionContext.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/ProtobufRpcEngine.proto
+++ b/internal/protocol/hadoop_common/ProtobufRpcEngine.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/ProtocolInfo.proto
+++ b/internal/protocol/hadoop_common/ProtocolInfo.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/RefreshAuthorizationPolicyProtocol.proto
+++ b/internal/protocol/hadoop_common/RefreshAuthorizationPolicyProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/RefreshCallQueueProtocol.proto
+++ b/internal/protocol/hadoop_common/RefreshCallQueueProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/RefreshUserMappingsProtocol.proto
+++ b/internal/protocol/hadoop_common/RefreshUserMappingsProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/RpcHeader.proto
+++ b/internal/protocol/hadoop_common/RpcHeader.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/Security.proto
+++ b/internal/protocol/hadoop_common/Security.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -60,4 +61,3 @@ message CancelDelegationTokenRequestProto {
 
 message CancelDelegationTokenResponseProto { // void response
 }
-

--- a/internal/protocol/hadoop_common/TraceAdmin.proto
+++ b/internal/protocol/hadoop_common/TraceAdmin.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_common/ZKFCProtocol.proto
+++ b/internal/protocol/hadoop_common/ZKFCProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/ClientDatanodeProtocol.proto
+++ b/internal/protocol/hadoop_hdfs/ClientDatanodeProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/ClientNamenodeProtocol.proto
+++ b/internal/protocol/hadoop_hdfs/ClientNamenodeProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/ReconfigurationProtocol.proto
+++ b/internal/protocol/hadoop_hdfs/ReconfigurationProtocol.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/acl.proto
+++ b/internal/protocol/hadoop_hdfs/acl.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/datatransfer.proto
+++ b/internal/protocol/hadoop_hdfs/datatransfer.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/encryption.proto
+++ b/internal/protocol/hadoop_hdfs/encryption.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/erasurecoding.proto
+++ b/internal/protocol/hadoop_hdfs/erasurecoding.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/hdfs.proto
+++ b/internal/protocol/hadoop_hdfs/hdfs.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/inotify.proto
+++ b/internal/protocol/hadoop_hdfs/inotify.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/internal/protocol/hadoop_hdfs/xattr.proto
+++ b/internal/protocol/hadoop_hdfs/xattr.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
protoc error was:

```
protoc-gen-go: error:inconsistent package import paths: ".", "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
```