### PR TITLE
Make Client.Remove non-recursive, add Client.RemoveAll

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -90,7 +90,7 @@ func touch(t *testing.T, path string) {
 func touchMask(t *testing.T, path string, mask os.FileMode) {
 	c := getClient(t)
 
-	err := c.Remove(path)
+	err := c.RemoveAll(path)
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func mkdirp(t *testing.T, path string) {
 func mkdirpMask(t *testing.T, path string, mask os.FileMode) {
 	c := getClient(t)
 
-	err := c.Remove(path)
+	err := c.RemoveAll(path)
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func mkdirpMask(t *testing.T, path string, mask os.FileMode) {
 func baleet(t *testing.T, path string) {
 	c := getClient(t)
 
-	err := c.Remove(path)
+	err := c.RemoveAll(path)
 	if err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)
 	}

--- a/cmd/hdfs/rm.go
+++ b/cmd/hdfs/rm.go
@@ -34,7 +34,7 @@ func rm(paths []string, recursive bool, force bool) {
 			continue
 		}
 
-		err = client.Remove(p)
+		err = client.RemoveAll(p)
 		if err != nil {
 			fatal(err)
 		}

--- a/error.go
+++ b/error.go
@@ -2,11 +2,13 @@ package hdfs
 
 import (
 	"os"
+	"syscall"
 )
 
 const (
-	fileNotFoundException     = "java.io.FileNotFoundException"
-	permissionDeniedException = "org.apache.hadoop.security.AccessControlException"
+	fileNotFoundException      = "java.io.FileNotFoundException"
+	permissionDeniedException  = "org.apache.hadoop.security.AccessControlException"
+	pathIsNotEmptyDirException = "org.apache.hadoop.fs.PathIsNotEmptyDirectoryException"
 )
 
 // Error represents a remote java exception from an HDFS namenode or datanode.
@@ -34,6 +36,8 @@ func interpretException(err error) error {
 		return os.ErrNotExist
 	case permissionDeniedException:
 		return os.ErrPermission
+	case pathIsNotEmptyDirException:
+		return syscall.ENOTEMPTY
 	default:
 		return err
 	}

--- a/remove.go
+++ b/remove.go
@@ -8,8 +8,17 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-// Remove removes the named file or directory.
+// Remove removes the named file or directory non-recursively.
 func (c *Client) Remove(name string) error {
+	return delete(c, name, false)
+}
+
+// RemoveAll removes the named file or directory recursively.
+func (c *Client) RemoveAll(name string) error {
+	return delete(c, name, true)
+}
+
+func delete(c *Client, name string, recursive bool) error {
 	_, err := c.getFileInfo(name)
 	if err != nil {
 		return &os.PathError{"remove", name, err}
@@ -17,7 +26,7 @@ func (c *Client) Remove(name string) error {
 
 	req := &hdfs.DeleteRequestProto{
 		Src:       proto.String(name),
-		Recursive: proto.Bool(true),
+		Recursive: proto.Bool(recursive),
 	}
 	resp := &hdfs.DeleteResponseProto{}
 

--- a/remove_test.go
+++ b/remove_test.go
@@ -2,19 +2,81 @@ package hdfs
 
 import (
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRemove(t *testing.T) {
+func TestRemoveAndRemoveAll(t *testing.T) {
+	funcs := map[string]func(*Client, string) error{
+		"Remove": func(c *Client, name string) error {
+			return c.Remove(name)
+		},
+		"RemoveAll": func(c *Client, name string) error {
+			return c.RemoveAll(name)
+		},
+	}
+
+	for fnName, fn := range funcs {
+		t.Run("Test"+fnName+"File", func(t *testing.T) {
+			client := getClient(t)
+
+			baleet(t, "/_test/todelete")
+			mkdirp(t, "/_test/todelete")
+			touch(t, "/_test/todelete/deleteme")
+
+			err := fn(client, "/_test/todelete/deleteme")
+			require.NoError(t, err)
+
+			fi, err := client.Stat("/_test/todelete/deleteme")
+			assert.Nil(t, fi)
+			assertPathError(t, err, "stat", "/_test/todelete/deleteme", os.ErrNotExist)
+		})
+
+		t.Run("Test"+fnName+"EmptyDir", func(t *testing.T) {
+			client := getClient(t)
+
+			baleet(t, "/_test/todelete")
+			mkdirp(t, "/_test/todelete")
+
+			err := fn(client, "/_test/todelete")
+			require.NoError(t, err)
+
+			fi, err := client.Stat("/_test/todelete")
+			assert.Nil(t, fi)
+			assertPathError(t, err, "stat", "/_test/todelete", os.ErrNotExist)
+		})
+
+		t.Run("Test"+fnName+"NotExistent", func(t *testing.T) {
+			client := getClient(t)
+			baleet(t, "/_test/nonexistent")
+
+			err := fn(client, "/_test/nonexistent")
+			assertPathError(t, err, "remove", "/_test/nonexistent", os.ErrNotExist)
+		})
+
+		t.Run("Test"+fnName+"WithoutPermission", func(t *testing.T) {
+			client := getClientForUser(t, "gohdfs2")
+
+			mkdirp(t, "/_test/accessdenied")
+			touch(t, "/_test/accessdenied/foo")
+
+			err := fn(client, "/_test/accessdenied/foo")
+			assertPathError(t, err, "remove", "/_test/accessdenied/foo", os.ErrPermission)
+		})
+	}
+}
+
+func TestRemoveAllNonEmptyDir(t *testing.T) {
 	client := getClient(t)
 
 	baleet(t, "/_test/todelete")
 	mkdirp(t, "/_test/todelete")
+	touch(t, "/_test/todelete/dummy")
 
-	err := client.Remove("/_test/todelete")
+	err := client.RemoveAll("/_test/todelete")
 	require.NoError(t, err)
 
 	fi, err := client.Stat("/_test/todelete")
@@ -22,21 +84,16 @@ func TestRemove(t *testing.T) {
 	assertPathError(t, err, "stat", "/_test/todelete", os.ErrNotExist)
 }
 
-func TestRemoveNotExistent(t *testing.T) {
+func TestRemoveNonEmptyDir(t *testing.T) {
 	client := getClient(t)
 
-	baleet(t, "/_test/nonexistent")
+	baleet(t, "/_test/todelete")
+	mkdirp(t, "/_test/todelete")
+	touch(t, "/_test/todelete/dummy")
 
-	err := client.Remove("/_test/nonexistent")
-	assertPathError(t, err, "remove", "/_test/nonexistent", os.ErrNotExist)
-}
-
-func TestRemoveWithoutPermission(t *testing.T) {
-	client2 := getClientForUser(t, "gohdfs2")
-
-	mkdirp(t, "/_test/accessdenied")
-	touch(t, "/_test/accessdenied/foo")
-
-	err := client2.Remove("/_test/accessdenied/foo")
-	assertPathError(t, err, "remove", "/_test/accessdenied/foo", os.ErrPermission)
+	err := client.Remove("/_test/todelete")
+	assertPathError(t, err, "remove", "/_test/todelete", syscall.ENOTEMPTY)
+	fi, err := client.Stat("/_test/todelete/dummy")
+	require.NoError(t, err)
+	assert.NotNil(t, fi)
 }


### PR DESCRIPTION
Fix an oversight in the implementation of Remove, which wasn't intended to be recursive. Also add a recursive version which is called RemoveAll.

This is a breaking API change that will not result in compilation errors.

~~Add a non recursive version of `Client.Remove()` which is named `Client.Delete()`.~~

~~I think the original method `Remove` should be called `RemoveAll`, and `Delete` in turn should be called `Remove`, but this would be definitely a cruel API change, so I just called it that way. Sorry for the not very clever name, suggestions welcome ;)~~