### PR TITLE
Add overwrite option to rename.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -38,7 +38,7 @@ func getClientForUser(t *testing.T, username string) *Client {
 
 	conf, err := hadoopconf.LoadFromEnvironment()
 	if err != nil || conf == nil {
-		t.Fatal("Couldn't load ambient config", err)
+		t.Fatal("Couldn't load ambient config", err, conf)
 	}
 
 	options := ClientOptionsFromConf(conf)

--- a/rename.go
+++ b/rename.go
@@ -1,6 +1,7 @@
 package hdfs
 
 import (
+	"errors"
 	"os"
 
 	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
@@ -25,6 +26,33 @@ func (c *Client) Rename(oldpath, newpath string) error {
 	err = c.namenode.Execute("rename2", req, resp)
 	if err != nil {
 		return &os.PathError{"rename", oldpath, interpretException(err)}
+	}
+
+	return nil
+}
+
+// RenameWithOverwrite renames (moves) a file. Overwrite option is taken as input.
+func (c *Client) RenameWithOverwriteOption(oldpath, newpath string, overwrite bool) error {
+	f, err := c.getFileInfo(newpath)
+	err = interpretException(err)
+	if err != nil && !os.IsNotExist(err) {
+		return &os.PathError{"rename", newpath, err}
+	}
+
+	if !overwrite && f != nil {
+		return &os.PathError{"rename", newpath, errors.New("Path exists.")}
+	}
+
+	req := &hdfs.Rename2RequestProto{
+		Src:           proto.String(oldpath),
+		Dst:           proto.String(newpath),
+		OverwriteDest: proto.Bool(overwrite),
+	}
+	resp := &hdfs.Rename2ResponseProto{}
+
+	err = c.namenode.Execute("rename2", req, resp)
+	if err != nil {
+		return &os.PathError{"rename_error", oldpath, interpretException(err)}
 	}
 
 	return nil

--- a/rename_test.go
+++ b/rename_test.go
@@ -66,3 +66,23 @@ func TestRenameWithoutPermissionForDest(t *testing.T) {
 	err = client2.Rename("/_test/ownedbyother2", "/_test/accessdenied/tomovedest4")
 	assertPathError(t, err, "rename", "/_test/accessdenied/tomovedest4", os.ErrPermission)
 }
+
+func TestRenameWithOverwrite(t *testing.T) {
+	client := getClientForUser(t, "gohdfs2")
+
+	touch(t, "/_test/tomove2")
+	touch(t, "/_test/tomovedest2")
+
+	err := client.RenameWithOverwriteOption("/_test/tomove2", "/_test/tomovedest2", true)
+	require.NoError(t, err)
+}
+
+func TestRenameWithOverwriteDestExists(t *testing.T) {
+	client := getClientForUser(t, "gohdfs2")
+
+	touch(t, "/_test/tomoveDestExists")
+	touch(t, "/_test/tomoveDestExists2")
+
+	err := client.RenameWithOverwriteOption("/_test/tomoveDestExists", "/_test/tomoveDestExists2", false)
+	require.Error(t, err)
+}


### PR DESCRIPTION
### Summary:
       With overwrite option, HDFS namenode leaks the inodes, when dest file exists.
       ISSUE: https://issues.apache.org/jira/browse/HDFS-6870

       This PR, gives an option to user for overwriting.

### Test Plan:
      go test