### PR TITLE
Implement SASL reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ go_import_path: github.com/colinmarc/hdfs
 go: 1.11beta2
 env:
 - PLATFORM=cdh5
-- PLATFORM=cdh5 KERBEROS=true
+- PLATFORM=cdh5 KERBEROS=true RPC_PROTECTION=authentication
+- PLATFORM=cdh5 KERBEROS=true RPC_PROTECTION=integrity
+- PLATFORM=cdh5 KERBEROS=true RPC_PROTECTION=privacy
 - PLATFORM=hdp2
 before_install:
 - export GO111MODULE=on # Travis installs into $GOPATH/src, which disables module support by default.

--- a/internal/rpc/challenge.go
+++ b/internal/rpc/challenge.go
@@ -1,0 +1,63 @@
+package rpc
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	hadoop "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
+)
+
+// QualityOfProtection is the level of security that is used when sending and receiving messages
+type QualityOfProtection string
+
+const (
+	// Authentication - Establishes mutual authentication between the client and the server
+	Authentication = QualityOfProtection("auth")
+	// Integrity - In addition to authentication, it guarantees that a man-in-the-middle cannot tamper with messages exchanged between the client and the server
+	Integrity = QualityOfProtection("auth-int")
+	// Privacy - In addition to the features offered by authentication and integrity, it also fully encrypts the messages exchanged between the client and the server
+	Privacy = QualityOfProtection("auth-conf")
+)
+
+var challengeRegexp = regexp.MustCompile(",?([a-zA-Z0-9]+)=(\"([^\"]+)\"|([^,]+)),?")
+
+// TokenChallenge is a struct which holds a challenge of TOKEN auth
+type TokenChallenge struct {
+	Realm     string
+	Nonce     string
+	QOP       QualityOfProtection
+	Charset   string
+	Cipher    []string
+	Algorithm string
+}
+
+// ParseChallenge returns a TokenChallenge parsed from a given SaslAuth
+func ParseChallenge(auth *hadoop.RpcSaslProto_SaslAuth) (*TokenChallenge, error) {
+	tokenChallenge := TokenChallenge{}
+	matched := challengeRegexp.FindAllSubmatch(auth.Challenge, -1)
+	if matched == nil {
+		return nil, errors.New("aaaa")
+	}
+	for _, m := range matched {
+		key := string(m[1])
+		val := string(m[3])
+		switch key {
+		case "realm":
+			tokenChallenge.Realm = val
+		case "nonce":
+			tokenChallenge.Nonce = val
+		case "qop":
+			tokenChallenge.QOP = QualityOfProtection(val)
+		case "charset":
+			tokenChallenge.Charset = val
+		case "cipher":
+			tokenChallenge.Cipher = strings.Split(val, ",")
+		case "algorithm":
+			tokenChallenge.Algorithm = val
+		default:
+			// skip
+		}
+	}
+	return &tokenChallenge, nil
+}

--- a/internal/rpc/challenge.go
+++ b/internal/rpc/challenge.go
@@ -34,7 +34,7 @@ func ParseChallenge(auth *hadoop.RpcSaslProto_SaslAuth) (*TokenChallenge, error)
 	tokenChallenge := TokenChallenge{}
 	matched := challengeRegexp.FindAllSubmatch(auth.Challenge, -1)
 	if matched == nil {
-		return nil, errors.New("aaaa")
+		return nil, errors.New("challenge format is invalid")
 	}
 	for _, m := range matched {
 		key := string(m[1])

--- a/internal/rpc/challenge.go
+++ b/internal/rpc/challenge.go
@@ -9,17 +9,17 @@ import (
 )
 
 const (
-	// Authentication - Establishes mutual authentication between the client and the server
+	// Authentication - Establishes mutual authentication between the client and the server.
 	Authentication = "auth"
-	// Integrity - In addition to authentication, it guarantees that a man-in-the-middle cannot tamper with messages exchanged between the client and the server
+	// Integrity - In addition to authentication, it guarantees that a man-in-the-middle cannot tamper with messages exchanged between the client and the server.
 	Integrity = "auth-int"
-	// Privacy - In addition to the features offered by authentication and integrity, it also fully encrypts the messages exchanged between the client and the server
+	// Privacy - In addition to the features offered by authentication and integrity, it also fully encrypts the messages exchanged between the client and the server.
 	Privacy = "auth-conf"
 )
 
 var challengeRegexp = regexp.MustCompile(",?([a-zA-Z0-9]+)=(\"([^\"]+)\"|([^,]+)),?")
 
-// TokenChallenge is a struct which holds a challenge of TOKEN auth
+// TokenChallenge is a struct which holds a challenge of TOKEN auth.
 type TokenChallenge struct {
 	Realm     string
 	Nonce     string
@@ -29,7 +29,7 @@ type TokenChallenge struct {
 	Algorithm string
 }
 
-// ParseChallenge returns a TokenChallenge parsed from a given SaslAuth
+// ParseChallenge returns a TokenChallenge parsed from a given SaslAuth.
 func ParseChallenge(auth *hadoop.RpcSaslProto_SaslAuth) (*TokenChallenge, error) {
 	tokenChallenge := TokenChallenge{}
 	matched := challengeRegexp.FindAllSubmatch(auth.Challenge, -1)

--- a/internal/rpc/challenge.go
+++ b/internal/rpc/challenge.go
@@ -8,16 +8,13 @@ import (
 	hadoop "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
 )
 
-// QualityOfProtection is the level of security that is used when sending and receiving messages
-type QualityOfProtection string
-
 const (
 	// Authentication - Establishes mutual authentication between the client and the server
-	Authentication = QualityOfProtection("auth")
+	Authentication = "auth"
 	// Integrity - In addition to authentication, it guarantees that a man-in-the-middle cannot tamper with messages exchanged between the client and the server
-	Integrity = QualityOfProtection("auth-int")
+	Integrity = "auth-int"
 	// Privacy - In addition to the features offered by authentication and integrity, it also fully encrypts the messages exchanged between the client and the server
-	Privacy = QualityOfProtection("auth-conf")
+	Privacy = "auth-conf"
 )
 
 var challengeRegexp = regexp.MustCompile(",?([a-zA-Z0-9]+)=(\"([^\"]+)\"|([^,]+)),?")
@@ -26,7 +23,7 @@ var challengeRegexp = regexp.MustCompile(",?([a-zA-Z0-9]+)=(\"([^\"]+)\"|([^,]+)
 type TokenChallenge struct {
 	Realm     string
 	Nonce     string
-	QOP       QualityOfProtection
+	QOP       string
 	Charset   string
 	Cipher    []string
 	Algorithm string
@@ -48,7 +45,7 @@ func ParseChallenge(auth *hadoop.RpcSaslProto_SaslAuth) (*TokenChallenge, error)
 		case "nonce":
 			tokenChallenge.Nonce = val
 		case "qop":
-			tokenChallenge.QOP = QualityOfProtection(val)
+			tokenChallenge.QOP = val
 		case "charset":
 			tokenChallenge.Charset = val
 		case "cipher":

--- a/internal/rpc/kerberos.go
+++ b/internal/rpc/kerberos.go
@@ -56,6 +56,7 @@ func (c *NamenodeConnection) doKerberosHandshake() error {
 	if err != nil {
 		return err
 	}
+	c.currentSessionKey = sessionKey
 
 	if tokenAuth != nil {
 		challenge, err := ParseChallenge(tokenAuth)

--- a/internal/rpc/kerberos.go
+++ b/internal/rpc/kerberos.go
@@ -62,12 +62,17 @@ func (c *NamenodeConnection) doKerberosHandshake() error {
 		if err != nil {
 			return err
 		}
-		if challenge.QOP == Privacy || challenge.QOP == Integrity {
+		switch challenge.QOP {
+		case Privacy, Integrity:
 			// Switch to SASL RPC handler
 			c.rpcReader = &SaslRpcReader{
 				SessionKey:      sessionKey,
 				Confidentiality: challenge.QOP == Privacy,
 			}
+		case Authentication:
+			// just use default RPC handler
+		default:
+			return errors.New("unexpected QOP")
 		}
 	}
 

--- a/internal/rpc/kerberos.go
+++ b/internal/rpc/kerberos.go
@@ -120,9 +120,6 @@ func (c *NamenodeConnection) doKerberosHandshake() error {
 
 	// Read the final response. If it's a SUCCESS, then we're done here.
 	_, err = c.readSaslResponse(hadoop.RpcSaslProto_SUCCESS)
-	if err != nil {
-		return err
-	}
 	return err
 }
 

--- a/internal/rpc/rpc_handler.go
+++ b/internal/rpc/rpc_handler.go
@@ -1,0 +1,172 @@
+package rpc
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	hadoop "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
+	"github.com/golang/protobuf/proto"
+	"gopkg.in/jcmturner/gokrb5.v5/crypto"
+	"gopkg.in/jcmturner/gokrb5.v5/gssapi"
+	"gopkg.in/jcmturner/gokrb5.v5/iana/keyusage"
+	krbtypes "gopkg.in/jcmturner/gokrb5.v5/types"
+)
+
+// To check interface validity
+var rpcWriter RpcWriter = &BasicRpcWriter{}
+var rpcReader RpcReader = &BasicRpcReader{}
+var saslRpcReader RpcReader = &SaslRpcReader{}
+
+// RpcWriter is an interface for sending RPC payload
+type RpcWriter interface {
+	WriteRequest(w io.Writer, method string, requestID int32, req proto.Message) error
+}
+
+// RpcReader is an interface for receiving RPC payload
+type RpcReader interface {
+	ReadResponse(r io.Reader, method string, requestID int32, resp proto.Message) error
+}
+
+// BasicRpcWriter is a basic RPC writer
+type BasicRpcWriter struct {
+	// ClientID is the client ID of this writer
+	ClientID []byte
+}
+
+// BasicRpcReader is a basic RPC reader
+type BasicRpcReader struct {
+}
+
+// SaslRpcReader is a RPC reader which wrap payload with SASL
+type SaslRpcReader struct {
+	// SessionKey is a encryption key used to decrypt payload
+	SessionKey krbtypes.EncryptionKey
+	// Confidentiality is a flag of message encryption
+	Confidentiality bool
+}
+
+// WriteRequest writes a request message
+//
+// A request packet:
+// +-----------------------------------------------------------+
+// |  uint32 length of the next three parts                    |
+// +-----------------------------------------------------------+
+// |  varint length + RpcRequestHeaderProto                    |
+// +-----------------------------------------------------------+
+// |  varint length + RequestHeaderProto                       |
+// +-----------------------------------------------------------+
+// |  varint length + Request                                  |
+// +-----------------------------------------------------------+
+func (writer *BasicRpcWriter) WriteRequest(w io.Writer, method string, requestID int32, req proto.Message) error {
+	rrh := newRPCRequestHeader(requestID, writer.ClientID)
+	rh := newRequestHeader(method)
+
+	reqBytes, err := makeRPCPacket(rrh, rh, req)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(reqBytes)
+	return err
+}
+
+// ReadResponse reads a response message
+//
+// A response from the namenode:
+// +-----------------------------------------------------------+
+// |  uint32 length of the next two parts                      |
+// +-----------------------------------------------------------+
+// |  varint length + RpcResponseHeaderProto                   |
+// +-----------------------------------------------------------+
+// |  varint length + Response                                 |
+// +-----------------------------------------------------------+
+func (reader *BasicRpcReader) ReadResponse(r io.Reader, method string, requestID int32, resp proto.Message) error {
+	rrh := &hadoop.RpcResponseHeaderProto{}
+	err := readRPCPacket(r, rrh, resp)
+	if err != nil {
+		return err
+	} else if int32(rrh.GetCallId()) != requestID {
+		return errors.New("unexpected sequence number")
+	} else if rrh.GetStatus() != hadoop.RpcResponseHeaderProto_SUCCESS {
+		return &NamenodeError{
+			method:    method,
+			message:   rrh.GetErrorMsg(),
+			code:      int(rrh.GetErrorDetail()),
+			exception: rrh.GetExceptionClassName(),
+		}
+	}
+
+	return nil
+}
+
+// ReadResponse reads a response message wrapped by SASL
+//
+// A response from the namenode:
+// +-----------------------------------------------------------+
+// |  uint32 length of the next two parts                      |
+// +-----------------------------------------------------------+
+// |  varint length + RpcResponseHeaderProto                   |
+// +-----------------------------------------------------------+
+// |  varint length + RpcSaslProto                             |
+// |       +---------------------------------------------------+
+// |       |  uint32 length of the next two parts              |
+// |       +---------------------------------------------------+
+// |       |  varint length + RpcResponseHeaderProto           |
+// |       +---------------------------------------------------+
+// |       |  varint length + Response                         |
+// +-----------------------------------------------------------+
+func (reader *SaslRpcReader) ReadResponse(r io.Reader, method string, requestID int32, resp proto.Message) error {
+	// read SASL payload first
+	rrh := &hadoop.RpcResponseHeaderProto{}
+	sasl := &hadoop.RpcSaslProto{}
+	err := readRPCPacket(r, rrh, sasl)
+	if err != nil {
+		return err
+	} else if sasl.GetState() != hadoop.RpcSaslProto_WRAP {
+		return fmt.Errorf("unexpected SASL state: %s", sasl.GetState().String())
+	}
+
+	// unwrap the token
+	var wrapToken gssapi.WrapToken
+	err = wrapToken.Unmarshal(sasl.GetToken(), true)
+	if err != nil {
+		return err
+	}
+
+	if reader.Confidentiality {
+		// decrypt the payload
+		decrypted, err := crypto.DecryptMessage(wrapToken.Payload, reader.SessionKey, keyusage.GSSAPI_ACCEPTOR_SEAL)
+		if err != nil {
+			return err
+		}
+		// read the decrypted message as a response
+		err = readRPCPacket(bytes.NewReader(decrypted), rrh, resp)
+		if err != nil {
+			return err
+		}
+	} else {
+		// verify checksum
+		_, err = wrapToken.VerifyCheckSum(reader.SessionKey, keyusage.GSSAPI_ACCEPTOR_SEAL)
+		if err != nil {
+			return fmt.Errorf("invalid server token: %s", err)
+		}
+		// read the original message as a response
+		err = readRPCPacket(bytes.NewReader(wrapToken.Payload), rrh, resp)
+		if err != nil {
+			return err
+		}
+	}
+	if int32(rrh.GetCallId()) != requestID {
+		return errors.New("unexpected sequence number")
+	} else if rrh.GetStatus() != hadoop.RpcResponseHeaderProto_SUCCESS {
+		return &NamenodeError{
+			method:    method,
+			message:   rrh.GetErrorMsg(),
+			code:      int(rrh.GetErrorDetail()),
+			exception: rrh.GetExceptionClassName(),
+		}
+	}
+	return nil
+}

--- a/internal/rpc/rpc_handler.go
+++ b/internal/rpc/rpc_handler.go
@@ -14,35 +14,35 @@ import (
 	krbtypes "gopkg.in/jcmturner/gokrb5.v5/types"
 )
 
-// RpcWriter is an interface for sending RPC payload
+// RpcWriter is an interface for sending RPC payload.
 type RpcWriter interface {
 	WriteRequest(w io.Writer, method string, requestID int32, req proto.Message) error
 }
 
-// RpcReader is an interface for receiving RPC payload
+// RpcReader is an interface for receiving RPC payload.
 type RpcReader interface {
 	ReadResponse(r io.Reader, method string, requestID int32, resp proto.Message) error
 }
 
-// BasicRpcWriter is a basic RPC writer
+// BasicRpcWriter is a basic RPC writer for HDFS.
 type BasicRpcWriter struct {
-	// ClientID is the client ID of this writer
+	// ClientID is the client ID of this writer.
 	ClientID []byte
 }
 
-// BasicRpcReader is a basic RPC reader
+// BasicRpcReader is a basic RPC reader for HDFS.
 type BasicRpcReader struct {
 }
 
-// SaslRpcReader is a RPC reader which wrap payload with SASL
+// SaslRpcReader is an RPC reader for HDFS with SASL encryption.
 type SaslRpcReader struct {
-	// SessionKey is a encryption key used to decrypt payload
+	// SessionKey is a encryption key used to decrypt payload.
 	SessionKey krbtypes.EncryptionKey
-	// Confidentiality is a flag of message encryption
+	// Confidentiality is a flag of message encryption.
 	Confidentiality bool
 }
 
-// WriteRequest writes a request message
+// WriteRequest writes a request message.
 //
 // A request packet:
 // +-----------------------------------------------------------+
@@ -67,7 +67,7 @@ func (writer *BasicRpcWriter) WriteRequest(w io.Writer, method string, requestID
 	return err
 }
 
-// ReadResponse reads a response message
+// ReadResponse reads a response message.
 //
 // A response from the namenode:
 // +-----------------------------------------------------------+
@@ -96,7 +96,7 @@ func (reader *BasicRpcReader) ReadResponse(r io.Reader, method string, requestID
 	return nil
 }
 
-// ReadResponse reads a response message wrapped by SASL
+// ReadResponse reads a response message wrapped by SASL.
 //
 // A response from the namenode:
 // +-----------------------------------------------------------+

--- a/internal/rpc/rpc_handler.go
+++ b/internal/rpc/rpc_handler.go
@@ -14,11 +14,6 @@ import (
 	krbtypes "gopkg.in/jcmturner/gokrb5.v5/types"
 )
 
-// To check interface validity
-var rpcWriter RpcWriter = &BasicRpcWriter{}
-var rpcReader RpcReader = &BasicRpcReader{}
-var saslRpcReader RpcReader = &SaslRpcReader{}
-
 // RpcWriter is an interface for sending RPC payload
 type RpcWriter interface {
 	WriteRequest(w io.Writer, method string, requestID int32, req proto.Message) error

--- a/travis-setup-cdh5.sh
+++ b/travis-setup-cdh5.sh
@@ -107,6 +107,10 @@ sudo tee /etc/hadoop/conf.gohdfs/core-site.xml <<EOF
     <name>dfs.datanode.kerberos.principal</name>
     <value>dn/localhost@$KERBEROS_REALM</value>
   </property>
+  <property>
+    <name>hadoop.rpc.protection</name>
+    <value>$RPC_PROTECTION</value>
+  </property>
 </configuration>
 EOF
 


### PR DESCRIPTION
I made RPC writing and reading interface and implemented SASL reader which is supposed to be used when a GSS API server responded with `TOKEN` auth and the QOP is `auth-conf` or `auth-int`.

I tried all the following patterns of qop config in `core-site.xml` and all of them work fine with this change.
- `hadoop.rpc.protection` : `authentication`
- `hadoop.rpc.protection` : `integrity`
- `hadoop.rpc.protection` : `privacy`

I didn't implement `SaslRpcWriter` as it requires a client to choose QOP and a lot of changes around the command line tool is necessary. I will start to implement it once this PR gets merged.

Solves: #144 