### PR TITLE
Add extended attributes support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/colinmarc/hdfs/v2
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.1.0
 	github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036 // indirect
 	github.com/jcmturner/gofork v0.0.0-20180107083740-2aebee971930 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,15 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
+github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036 h1:d8T6WIONl4rMCPcQ/eY3uSz3+e4/GaoflKjXrWMex1U=
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/jcmturner/gofork v0.0.0-20180107083740-2aebee971930 h1:v4CYlQ+HeysPHsr2QFiEO60gKqnvn1xwvuKhhAhuEkk=
 github.com/jcmturner/gofork v0.0.0-20180107083740-2aebee971930/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
+github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117 h1:7822vZ646Atgxkp3tqrSufChvAAYgIy+iFEGpQntwlI=
 github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -15,6 +19,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb h1:Ah9YqXLj6fEgeKqcmBuLCbAsrF3ScD7dJ/bYM0C6tXI=
 golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/jcmturner/aescts.v1 v1.0.1 h1:cVVZBK2b1zY26haWB4vbBiZrfFQnfbTVrE3xZq6hrEw=
 gopkg.in/jcmturner/aescts.v1 v1.0.1/go.mod h1:nsR8qBOg+OucoIW+WMhB3GspUQXq9XorLnQb9XtvcOo=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1 h1:cIuC1OLRGZrld+16ZJvvZxVJeKPsvd5eUIvxfoN5hSM=

--- a/xattr.go
+++ b/xattr.go
@@ -1,0 +1,94 @@
+package hdfs
+
+import (
+	"os"
+
+	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	"github.com/gogo/protobuf/proto"
+)
+
+// ListUserAttrs - returns a list of all extended attributes from user namespace,
+// returned is a map of key and values.
+func (c *Client) ListUserAttrs(name string) (map[string]string, error) {
+	req := &hdfs.ListXAttrsRequestProto{Src: proto.String(name)}
+	resp := &hdfs.ListXAttrsResponseProto{}
+
+	err := c.namenode.Execute("listXAttrs", req, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.GetXAttrs() == nil {
+		return nil, os.ErrNotExist
+	}
+
+	m := make(map[string]string)
+	for _, xattr := range resp.GetXAttrs() {
+		m[xattr.GetName()] = string(xattr.GetValue())
+
+	}
+	return m, nil
+}
+
+// RemoveUserAttr - removes a given user namespace extended attribute
+func (c *Client) RemoveUserAttr(name, key string) error {
+	req := &hdfs.RemoveXAttrRequestProto{
+		Src: proto.String(name),
+		XAttr: &hdfs.XAttrProto{
+			Namespace: hdfs.XAttrProto_USER.Enum(),
+			Name:      proto.String(key),
+		},
+	}
+	resp := &hdfs.RemoveXAttrResponseProto{}
+
+	return c.namenode.Execute("removeXAttr", req, resp)
+}
+
+// SetUserAttr - sets a extended attributed user namespace key,
+// with the specified value.
+func (c *Client) SetUserAttr(name, key, value string) error {
+	var flag uint32 = 2
+	req := &hdfs.SetXAttrRequestProto{
+		Src: proto.String(name),
+		XAttr: &hdfs.XAttrProto{
+			Namespace: hdfs.XAttrProto_USER.Enum(),
+			Name:      proto.String(key),
+			Value:     []byte(value),
+		},
+		Flag: &flag,
+	}
+	resp := &hdfs.SetXAttrResponseProto{}
+
+	return c.namenode.Execute("setXAttr", req, resp)
+}
+
+// GetUserAttrs - gets all the user namespace extended attributes, returned
+// value is in key value map string of string. Optionally you can provide
+// specific keys to get values from.
+func (c *Client) GetUserAttrs(name string, keys ...string) (map[string]string, error) {
+
+	req := &hdfs.GetXAttrsRequestProto{Src: proto.String(name)}
+	for _, key := range keys {
+		req.XAttrs = append(req.XAttrs, &hdfs.XAttrProto{
+			Namespace: hdfs.XAttrProto_USER.Enum(),
+			Name:      proto.String(key),
+		})
+	}
+	resp := &hdfs.GetXAttrsResponseProto{}
+
+	err := c.namenode.Execute("getXAttrs", req, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.GetXAttrs() == nil {
+		return nil, os.ErrNotExist
+	}
+
+	m := make(map[string]string)
+	for _, xattr := range resp.GetXAttrs() {
+		m[xattr.GetName()] = string(xattr.GetValue())
+
+	}
+	return m, nil
+}


### PR DESCRIPTION
The scope of this PR is to only support user extended attributes,
setting other extended attributes such as in `trusted` namespace
is not useful without having system priviledges.