### PR TITLE
Revert module name by removing v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GENERATED_PROTOS = $(shell echo "$(HADOOP_HDFS_PROTOS) $(HADOOP_COMMON_PROTOS)" 
 SOURCES = $(shell find . -name '*.go') $(GENERATED_PROTOS)
 
 # Protobuf needs one of these for every 'import "foo.proto"' in .protoc files.
-PROTO_MAPPING = MSecurity.proto=github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common
+PROTO_MAPPING = MSecurity.proto=github.com/colinmarc/hdfs/internal/protocol/hadoop_common
 
 TRAVIS_TAG ?= $(shell git rev-parse HEAD)
 ARCH = $(shell go env GOOS)-$(shell go env GOARCH)

--- a/client.go
+++ b/client.go
@@ -10,9 +10,9 @@ import (
 	"os/user"
 	"strings"
 
-	"github.com/colinmarc/hdfs/v2/hadoopconf"
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
-	"github.com/colinmarc/hdfs/v2/internal/rpc"
+	"github.com/colinmarc/hdfs/hadoopconf"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
+	"github.com/colinmarc/hdfs/internal/rpc"
 	krb "gopkg.in/jcmturner/gokrb5.v5/client"
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/colinmarc/hdfs/v2/hadoopconf"
+	"github.com/colinmarc/hdfs/hadoopconf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	krb "gopkg.in/jcmturner/gokrb5.v5/client"

--- a/cmd/hdfs/cat.go
+++ b/cmd/hdfs/cat.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/colinmarc/hdfs/v2"
+	"github.com/colinmarc/hdfs"
 )
 
 const tailSearchSize int64 = 16384

--- a/cmd/hdfs/df.go
+++ b/cmd/hdfs/df.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/colinmarc/hdfs/v2"
+	"github.com/colinmarc/hdfs"
 )
 
 func df(humanReadable bool) {

--- a/cmd/hdfs/du.go
+++ b/cmd/hdfs/du.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"text/tabwriter"
 
-	"github.com/colinmarc/hdfs/v2"
+	"github.com/colinmarc/hdfs"
 )
 
 func du(args []string, summarize, humanReadable bool) {

--- a/cmd/hdfs/ls.go
+++ b/cmd/hdfs/ls.go
@@ -10,7 +10,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/colinmarc/hdfs/v2"
+	"github.com/colinmarc/hdfs"
 )
 
 func ls(paths []string, long, all, humanReadable bool) {

--- a/cmd/hdfs/main.go
+++ b/cmd/hdfs/main.go
@@ -8,8 +8,8 @@ import (
 	"os/user"
 	"time"
 
-	"github.com/colinmarc/hdfs/v2"
-	"github.com/colinmarc/hdfs/v2/hadoopconf"
+	"github.com/colinmarc/hdfs"
+	"github.com/colinmarc/hdfs/hadoopconf"
 	"github.com/pborman/getopt"
 )
 

--- a/cmd/hdfs/mv.go
+++ b/cmd/hdfs/mv.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/colinmarc/hdfs/v2"
+	"github.com/colinmarc/hdfs"
 )
 
 func mv(paths []string, force, treatDestAsFile bool) {

--- a/cmd/hdfs/paths.go
+++ b/cmd/hdfs/paths.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/colinmarc/hdfs/v2"
+	"github.com/colinmarc/hdfs"
 )
 
 var (

--- a/cmd/hdfs/put.go
+++ b/cmd/hdfs/put.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/colinmarc/hdfs/v2"
+	"github.com/colinmarc/hdfs"
 )
 
 func put(args []string) {

--- a/content_summary.go
+++ b/content_summary.go
@@ -3,7 +3,7 @@ package hdfs
 import (
 	"os"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/file_reader.go
+++ b/file_reader.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
-	"github.com/colinmarc/hdfs/v2/internal/rpc"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
+	"github.com/colinmarc/hdfs/internal/rpc"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/file_writer.go
+++ b/file_writer.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
-	"github.com/colinmarc/hdfs/v2/internal/rpc"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
+	"github.com/colinmarc/hdfs/internal/rpc"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/colinmarc/hdfs/v2
+module github.com/colinmarc/hdfs
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect

--- a/internal/protocol/hadoop_hdfs/ClientDatanodeProtocol.pb.go
+++ b/internal/protocol/hadoop_hdfs/ClientDatanodeProtocol.pb.go
@@ -6,7 +6,7 @@ package hadoop_hdfs
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import hadoop_common "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
+import hadoop_common "github.com/colinmarc/hdfs/internal/protocol/hadoop_common"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/internal/protocol/hadoop_hdfs/ClientNamenodeProtocol.pb.go
+++ b/internal/protocol/hadoop_hdfs/ClientNamenodeProtocol.pb.go
@@ -6,7 +6,7 @@ package hadoop_hdfs
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
+import _ "github.com/colinmarc/hdfs/internal/protocol/hadoop_common"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/internal/protocol/hadoop_hdfs/datatransfer.pb.go
+++ b/internal/protocol/hadoop_hdfs/datatransfer.pb.go
@@ -6,7 +6,7 @@ package hadoop_hdfs
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import hadoop_common "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
+import hadoop_common "github.com/colinmarc/hdfs/internal/protocol/hadoop_common"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/internal/protocol/hadoop_hdfs/hdfs.pb.go
+++ b/internal/protocol/hadoop_hdfs/hdfs.pb.go
@@ -6,7 +6,7 @@ package hadoop_hdfs
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import hadoop_common "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
+import hadoop_common "github.com/colinmarc/hdfs/internal/protocol/hadoop_common"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/internal/rpc/block_read_stream.go
+++ b/internal/rpc/block_read_stream.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"math"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/internal/rpc/block_reader.go
+++ b/internal/rpc/block_reader.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"time"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/internal/rpc/block_write_stream.go
+++ b/internal/rpc/block_write_stream.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"math"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/internal/rpc/block_writer.go
+++ b/internal/rpc/block_writer.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"time"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/internal/rpc/checksum_reader.go
+++ b/internal/rpc/checksum_reader.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"time"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 )
 
 // ChecksumReader provides an interface for reading the "MD5CRC32" checksums of

--- a/internal/rpc/error.go
+++ b/internal/rpc/error.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"fmt"
 
-	hadoop "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
+	hadoop "github.com/colinmarc/hdfs/internal/protocol/hadoop_common"
 )
 
 // NamenodeError represents an interepreted error from the Namenode, including

--- a/internal/rpc/kerberos.go
+++ b/internal/rpc/kerberos.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"regexp"
 
-	hadoop "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
+	hadoop "github.com/colinmarc/hdfs/internal/protocol/hadoop_common"
 	"gopkg.in/jcmturner/gokrb5.v5/gssapi"
 	"gopkg.in/jcmturner/gokrb5.v5/iana/keyusage"
 	krbtypes "gopkg.in/jcmturner/gokrb5.v5/types"

--- a/internal/rpc/namenode.go
+++ b/internal/rpc/namenode.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	hadoop "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
+	hadoop "github.com/colinmarc/hdfs/internal/protocol/hadoop_common"
 	"github.com/golang/protobuf/proto"
 	krb "gopkg.in/jcmturner/gokrb5.v5/client"
 )

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -10,7 +10,7 @@ import (
 	"math/rand"
 	"time"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/mkdir.go
+++ b/mkdir.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"path"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/perms.go
+++ b/perms.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/remove.go
+++ b/remove.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"os"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/rename.go
+++ b/rename.go
@@ -3,7 +3,7 @@ package hdfs
 import (
 	"os"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/stat.go
+++ b/stat.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"time"
 
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/stat_fs.go
+++ b/stat_fs.go
@@ -1,7 +1,7 @@
 package hdfs
 
 import (
-	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	hdfs "github.com/colinmarc/hdfs/internal/protocol/hadoop_hdfs"
 )
 
 // FsInfo provides information about HDFS


### PR DESCRIPTION
Adding tags like `v2.0.0` is better than renaming module name.
[argoproj](https://github.com/argoproj/argo/) builds are broken.