### PR TITLE
added go.mod to build and use hadoopconf package properly

### DIFF
--- a/hadoopconf/go.mod
+++ b/hadoopconf/go.mod
@@ -1,0 +1,3 @@
+module github.com/colinmarc/hdfs/hadoopconf
+
+go 1.12


### PR DESCRIPTION
please review and add. You can reject this and add your own - whatever you wish, we need to be able to use hadoopconf package properly.

Thanks in advance!