### PR TITLE
Fix internal/rpc.readPrefixedMessage to read message length correctly

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -111,7 +111,7 @@ func makePrefixedMessage(msg proto.Message) ([]byte, error) {
 
 func readPrefixedMessage(r io.Reader, msg proto.Message) error {
 	varintBytes := make([]byte, binary.MaxVarintLen32)
-	_, err := io.ReadAtLeast(r, varintBytes, 1)
+	_, err := io.ReadAtLeast(r, varintBytes, binary.MaxVarintLen32)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`readAtLeast` will sometimes (very rarely) read less than `MaxVarIntLen32` bytes since the code is asking only for a guarantee of 1 byte to be read. In that case, the length of the buffer to be decoded could be wrong. And even if the buffer is small and the length is only one byte, the code assumes `MaxVarIntLen32` bytes are read and goes on to copy zeroes into the buffer to be unmarshalled.  Protobuf decoding then fails with a delightful error message: _illegal tag 0 (wire type 0)_
There is a `readUVarint` method that can be used instead. This eliminates the need to do the copying as well. Note that we need to wrap  `io.Reader` in a `bufio.Reader` since `readUVarint` requires `io.ByteReader` 