### PR TITLE
Add snapshots to v2

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,72 @@
+package hdfs
+
+import (
+	hdfs "github.com/colinmarc/hdfs/protocol/hadoop_hdfs"
+	"github.com/colinmarc/hdfs/rpc"
+)
+
+func (c *Client) AllowSnapshots(dir string) error {
+	allowSnapshotReq := &hdfs.AllowSnapshotRequestProto{SnapshotRoot: &dir}
+	allowSnapshotRes := &hdfs.AllowSnapshotResponseProto{}
+
+	err := c.namenode.Execute("allowSnapshot", allowSnapshotReq, allowSnapshotRes)
+	if err != nil {
+		if nnErr, ok := err.(*rpc.NamenodeError); ok {
+			err = interpretException(nnErr.Exception, err)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) DisallowSnapshots(dir string) error {
+	disallowSnapshotReq := &hdfs.DisallowSnapshotRequestProto{SnapshotRoot: &dir}
+	disallowSnapshotRes := &hdfs.DisallowSnapshotResponseProto{}
+
+	err := c.namenode.Execute("disallowSnapshot", disallowSnapshotReq, disallowSnapshotRes)
+	if err != nil {
+		if nnErr, ok := err.(*rpc.NamenodeError); ok {
+			err = interpretException(nnErr.Exception, err)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) CreateSnapshot(dir, name string) (string, error) {
+	allowSnapshotReq := &hdfs.CreateSnapshotRequestProto{
+		SnapshotRoot: &dir,
+		SnapshotName: &name,
+	}
+	allowSnapshotRes := &hdfs.CreateSnapshotResponseProto{}
+
+	err := c.namenode.Execute("createSnapshot", allowSnapshotReq, allowSnapshotRes)
+	if err != nil {
+		if nnErr, ok := err.(*rpc.NamenodeError); ok {
+			err = interpretException(nnErr.Exception, err)
+		}
+		return "", err
+	}
+
+	return allowSnapshotRes.GetSnapshotPath(), nil
+}
+
+func (c *Client) DeleteSnapshot(dir, name string) error {
+	allowSnapshotReq := &hdfs.DeleteSnapshotRequestProto{
+		SnapshotRoot: &dir,
+		SnapshotName: &name,
+	}
+	allowSnapshotRes := &hdfs.DeleteSnapshotResponseProto{}
+
+	err := c.namenode.Execute("deleteSnapshot", allowSnapshotReq, allowSnapshotRes)
+	if err != nil {
+		if nnErr, ok := err.(*rpc.NamenodeError); ok {
+			err = interpretException(nnErr.Exception, err)
+		}
+		return err
+	}
+
+	return nil
+}

--- a/snapshot.go
+++ b/snapshot.go
@@ -5,6 +5,11 @@ import (
 	"github.com/colinmarc/hdfs/rpc"
 )
 
+// AllowSnapshots marks a directory as available for snapshots.
+// This is required to make a snapshot of a directory as snapshottable
+// directories work as a whitelist.
+//
+// This requires superuser privileges.
 func (c *Client) AllowSnapshots(dir string) error {
 	allowSnapshotReq := &hdfs.AllowSnapshotRequestProto{SnapshotRoot: &dir}
 	allowSnapshotRes := &hdfs.AllowSnapshotResponseProto{}
@@ -20,6 +25,9 @@ func (c *Client) AllowSnapshots(dir string) error {
 	return nil
 }
 
+// DisallowSnapshots marks a directory as unavailable for snapshots.
+//
+// This requires superuser privileges.
 func (c *Client) DisallowSnapshots(dir string) error {
 	disallowSnapshotReq := &hdfs.DisallowSnapshotRequestProto{SnapshotRoot: &dir}
 	disallowSnapshotRes := &hdfs.DisallowSnapshotResponseProto{}
@@ -35,6 +43,10 @@ func (c *Client) DisallowSnapshots(dir string) error {
 	return nil
 }
 
+// CreateSnapshots creates a snapshot of a given directory and name, and
+// returns the path containing the snapshot. Snapshot names must be unique.
+//
+// This requires superuser privileges.
 func (c *Client) CreateSnapshot(dir, name string) (string, error) {
 	allowSnapshotReq := &hdfs.CreateSnapshotRequestProto{
 		SnapshotRoot: &dir,
@@ -53,6 +65,9 @@ func (c *Client) CreateSnapshot(dir, name string) (string, error) {
 	return allowSnapshotRes.GetSnapshotPath(), nil
 }
 
+// CreateSnapshots deletes a snapshot with a given directory and name.
+//
+// This requires superuser privileges.
 func (c *Client) DeleteSnapshot(dir, name string) error {
 	allowSnapshotReq := &hdfs.DeleteSnapshotRequestProto{
 		SnapshotRoot: &dir,

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,8 +1,7 @@
 package hdfs
 
 import (
-	hdfs "github.com/colinmarc/hdfs/protocol/hadoop_hdfs"
-	"github.com/colinmarc/hdfs/rpc"
+	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
 )
 
 // AllowSnapshots marks a directory as available for snapshots.
@@ -16,10 +15,7 @@ func (c *Client) AllowSnapshots(dir string) error {
 
 	err := c.namenode.Execute("allowSnapshot", allowSnapshotReq, allowSnapshotRes)
 	if err != nil {
-		if nnErr, ok := err.(*rpc.NamenodeError); ok {
-			err = interpretException(nnErr.Exception, err)
-		}
-		return err
+		return interpretException(err)
 	}
 
 	return nil
@@ -34,10 +30,7 @@ func (c *Client) DisallowSnapshots(dir string) error {
 
 	err := c.namenode.Execute("disallowSnapshot", disallowSnapshotReq, disallowSnapshotRes)
 	if err != nil {
-		if nnErr, ok := err.(*rpc.NamenodeError); ok {
-			err = interpretException(nnErr.Exception, err)
-		}
-		return err
+		return interpretException(err)
 	}
 
 	return nil
@@ -56,10 +49,7 @@ func (c *Client) CreateSnapshot(dir, name string) (string, error) {
 
 	err := c.namenode.Execute("createSnapshot", allowSnapshotReq, allowSnapshotRes)
 	if err != nil {
-		if nnErr, ok := err.(*rpc.NamenodeError); ok {
-			err = interpretException(nnErr.Exception, err)
-		}
-		return "", err
+		return "", interpretException(err)
 	}
 
 	return allowSnapshotRes.GetSnapshotPath(), nil
@@ -77,11 +67,7 @@ func (c *Client) DeleteSnapshot(dir, name string) error {
 
 	err := c.namenode.Execute("deleteSnapshot", allowSnapshotReq, allowSnapshotRes)
 	if err != nil {
-		if nnErr, ok := err.(*rpc.NamenodeError); ok {
-			err = interpretException(nnErr.Exception, err)
-		}
-		return err
+		return interpretException(err)
 	}
-
 	return nil
 }

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,0 +1,113 @@
+package hdfs
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeAndVerifyTestFile(t *testing.T, snapshotDir, filepath string) {
+	c := getClient(t)
+
+	baleet(t, filepath)
+	mkdirp(t, snapshotDir)
+
+	f, err := c.CreateFile(filepath, 1, 1048576, 0744)
+	require.NoError(t, err)
+
+	// fill the file a bit
+	b := make([]byte, 128)
+	for i := 0; i < 128; i++ {
+		b[i] = 'a'
+	}
+
+	_, err = f.Write(b)
+	require.NoError(t, err)
+	f.Close()
+
+	nf, err := c.Open(filepath)
+	require.NoError(t, err)
+
+	br, err := ioutil.ReadAll(nf)
+	require.NoError(t, err)
+	nf.Close()
+
+	assert.Equal(t, b, br)
+}
+
+func baleetSnapshot(t *testing.T, dir, snapshot string) {
+	c := getClient(t)
+	c.DeleteSnapshot(dir, snapshot)
+}
+
+func TestAllowSnapshot(t *testing.T) {
+	c := getClient(t)
+	baleetSnapshot(t, "/_test/allowsnaps", "snap")
+	mkdirp(t, "/_test/allowsnaps")
+	err := c.AllowSnapshots("/_test/allowsnaps")
+	require.NoError(t, err)
+	path, err := c.CreateSnapshot("/_test/allowsnaps", "snap")
+	require.NoError(t, err)
+	assert.Equal(t, "/_test/allowsnaps/.snapshot/snap", path)
+}
+
+func TestDisallowSnapshot(t *testing.T) {
+	c := getClient(t)
+	baleetSnapshot(t, "/_test/allowsnaps", "snap")
+	mkdirp(t, "/_test/allowsnaps")
+	err := c.DisallowSnapshots("/_test/allowsnaps")
+	require.NoError(t, err)
+	_, err = c.CreateSnapshot("/_test/allowsnaps", "snap")
+	require.Error(t, err)
+}
+
+func TestSnapshot(t *testing.T) {
+	const name = "TestSnapshot"
+	const dir = "/_test/snapshot"
+	const filename = "file_to_restore.txt"
+	const filepath = "/_test/snapshot/file_to_restore.txt"
+
+	c := getClient(t)
+	baleetSnapshot(t, dir, name)
+
+	writeAndVerifyTestFile(t, dir, filepath)
+
+	err := c.AllowSnapshots(dir)
+	require.NoError(t, err)
+
+	snapshotPath, err := c.CreateSnapshot(dir, name)
+	require.NoError(t, err)
+
+	err = c.Remove(filepath)
+	require.NoError(t, err)
+
+	_, err = c.Stat(filepath)
+	assertPathError(t, err, "stat", filepath, os.ErrNotExist)
+
+	st, err := c.Stat(path.Join(snapshotPath, filename))
+	require.NoError(t, err)
+	assert.Equal(t, int64(128), st.Size())
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	c := getClient(t)
+	baleetSnapshot(t, "/_test/deletesnaps", "snap")
+	mkdirp(t, "/_test/deletesnaps")
+	err := c.AllowSnapshots("/_test/deletesnaps")
+	require.NoError(t, err)
+	path, err := c.CreateSnapshot("/_test/deletesnaps", "snap")
+	require.NoError(t, err)
+
+	fs, err := c.Stat(path)
+	assert.True(t, fs.IsDir())
+
+	err = c.DeleteSnapshot("/_test/deletesnaps", "snap")
+	require.NoError(t, err)
+
+	_, err = c.Stat(path)
+	assertPathError(t, err, "stat", path, os.ErrNotExist)
+}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func writeAndVerifyTestFile(t *testing.T, snapshotDir, filepath string) {
-	c := getClient(t)
+	c := getClientForSuperUser(t)
 
 	baleet(t, filepath)
 	mkdirp(t, snapshotDir)
@@ -40,12 +40,12 @@ func writeAndVerifyTestFile(t *testing.T, snapshotDir, filepath string) {
 }
 
 func baleetSnapshot(t *testing.T, dir, snapshot string) {
-	c := getClient(t)
+	c := getClientForSuperUser(t)
 	c.DeleteSnapshot(dir, snapshot)
 }
 
 func TestAllowSnapshot(t *testing.T) {
-	c := getClient(t)
+	c := getClientForSuperUser(t)
 	baleetSnapshot(t, "/_test/allowsnaps", "snap")
 	mkdirp(t, "/_test/allowsnaps")
 	err := c.AllowSnapshots("/_test/allowsnaps")
@@ -56,7 +56,7 @@ func TestAllowSnapshot(t *testing.T) {
 }
 
 func TestDisallowSnapshot(t *testing.T) {
-	c := getClient(t)
+	c := getClientForSuperUser(t)
 	baleetSnapshot(t, "/_test/allowsnaps", "snap")
 	mkdirp(t, "/_test/allowsnaps")
 	err := c.DisallowSnapshots("/_test/allowsnaps")
@@ -71,7 +71,7 @@ func TestSnapshot(t *testing.T) {
 	const filename = "file_to_restore.txt"
 	const filepath = "/_test/snapshot/file_to_restore.txt"
 
-	c := getClient(t)
+	c := getClientForSuperUser(t)
 	baleetSnapshot(t, dir, name)
 
 	writeAndVerifyTestFile(t, dir, filepath)
@@ -94,7 +94,7 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestDeleteSnapshot(t *testing.T) {
-	c := getClient(t)
+	c := getClientForSuperUser(t)
 	baleetSnapshot(t, "/_test/deletesnaps", "snap")
 	mkdirp(t, "/_test/deletesnaps")
 	err := c.AllowSnapshots("/_test/deletesnaps")


### PR DESCRIPTION
I'm not sure if this repo is actively maintained, but in case it is, here's some features for snapshots. This was ported from v1.

This adds the following functions to :

- AllowSnapshot
- DisallowSnapshot
- CreateSnapshot
- DeleteSnapshot