### PR TITLE
return error from Close() on incomplete writes

### DIFF
--- a/file_writer.go
+++ b/file_writer.go
@@ -1,6 +1,7 @@
 package hdfs
 
 import (
+	"errors"
 	"io"
 	"os"
 	"time"
@@ -231,7 +232,10 @@ func (f *FileWriter) Close() error {
 
 	err := f.client.namenode.Execute("complete", completeReq, completeResp)
 	if err != nil {
-		return &os.PathError{"create", f.name, err}
+		return &os.PathError{Op: "close", Path: f.name, Err: err}
+	}
+	if *completeResp.Result != true {
+		return &os.PathError{Op: "close", Path: f.name, Err: errors.New("incomplete write")}
 	}
 
 	return nil


### PR DESCRIPTION
If there's an under-replicated block reported on Close(), the hdfs client would previously just ignore it. This way at least the error is reported.

In this instance, the namenode logs look something like:
```
hadoop-hdfs-namenode-namenode-1.log.4:2020-06-10 22:05:56,857 INFO 
 namenode.FSNamesystem (FSNamesystem.java:isCompleteBlock(3908)) - BLOCK*
 blk_1074123929_400791{UCState=COMMITTED, truncateBlock=null, primaryNodeIndex=-1,
 replicas=[ReplicaUC[[DISK]DS-f884c339-b70e-42ee-b8d7-b23cc5977d3f:NORMAL:1.1.1.18:50010|RBW],
 ReplicaUC[[DISK]DS-e3bd2ad1-ad0e-4e09-870d-a372bd277793:NORMAL:1.1.1.17:50010|RBW]]}
 is not COMPLETE (ucState = COMMITTED, replication# = 1 <  minimum = 2) in file /foo/bar/baz
```

so the `complete` RPC returns successfully, but it's returning an result with complete=false.