### PR TITLE
Add extended attributes support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 hdfs
 !hdfs/
 minicluster.log
+*.test

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,12 @@
 module github.com/colinmarc/hdfs/v2
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/golang/protobuf v1.1.0
 	github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036 // indirect
 	github.com/jcmturner/gofork v0.0.0-20180107083740-2aebee971930 // indirect
 	github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.6.1
+	github.com/tj/assert v0.0.3
 	golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	gopkg.in/jcmturner/aescts.v1 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036 h1:d8T6WIONl4rMCPcQ/eY3uSz3+e4/GaoflKjXrWMex1U=
@@ -10,12 +12,17 @@ github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117 h1:7822vZ646Atgxkp3
 github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
+github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb h1:Ah9YqXLj6fEgeKqcmBuLCbAsrF3ScD7dJ/bYM0C6tXI=
 golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/jcmturner/aescts.v1 v1.0.1 h1:cVVZBK2b1zY26haWB4vbBiZrfFQnfbTVrE3xZq6hrEw=
 gopkg.in/jcmturner/aescts.v1 v1.0.1/go.mod h1:nsR8qBOg+OucoIW+WMhB3GspUQXq9XorLnQb9XtvcOo=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1 h1:cIuC1OLRGZrld+16ZJvvZxVJeKPsvd5eUIvxfoN5hSM=
@@ -26,3 +33,6 @@ gopkg.in/jcmturner/gokrb5.v7 v7.3.0 h1:0709Jtq/6QXEuWRfAm260XqlpcwL1vxtO1tUE2qK8
 gopkg.in/jcmturner/gokrb5.v7 v7.3.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0 h1:QHIUxTX1ISuAv9dD2wJ9HWQVuWDX/Zc0PfeC2tjc4rU=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/xattr.go
+++ b/xattr.go
@@ -1,0 +1,93 @@
+package hdfs
+
+import (
+	"os"
+
+	hdfs "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_hdfs"
+	"github.com/golang/protobuf/proto"
+)
+
+// ListUserAttrs - returns a list of all extended attributes from user namespace,
+// returned is a map of key and values.
+func (c *Client) ListUserAttrs(name string) (map[string]string, error) {
+	req := &hdfs.ListXAttrsRequestProto{Src: proto.String(name)}
+	resp := &hdfs.ListXAttrsResponseProto{}
+
+	err := c.namenode.Execute("listXAttrs", req, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.GetXAttrs() == nil {
+		return nil, os.ErrNotExist
+	}
+
+	m := make(map[string]string)
+	for _, xattr := range resp.GetXAttrs() {
+		m[xattr.GetName()] = string(xattr.GetValue())
+
+	}
+	return m, nil
+}
+
+// RemoveUserAttr - removes a given user namespace extended attribute
+func (c *Client) RemoveUserAttr(name, key string) error {
+	req := &hdfs.RemoveXAttrRequestProto{
+		Src: proto.String(name),
+		XAttr: &hdfs.XAttrProto{
+			Namespace: hdfs.XAttrProto_USER.Enum(),
+			Name:      proto.String(key),
+		},
+	}
+	resp := &hdfs.RemoveXAttrResponseProto{}
+
+	return c.namenode.Execute("removeXAttr", req, resp)
+}
+
+// SetUserAttr - sets a extended attributed user namespace key,
+// with the specified value.
+func (c *Client) SetUserAttr(name, key, value string) error {
+	var flag uint32 = 2
+	req := &hdfs.SetXAttrRequestProto{
+		Src: proto.String(name),
+		XAttr: &hdfs.XAttrProto{
+			Namespace: hdfs.XAttrProto_USER.Enum(),
+			Name:      proto.String(key),
+			Value:     []byte(value),
+		},
+		Flag: &flag,
+	}
+	resp := &hdfs.SetXAttrResponseProto{}
+
+	return c.namenode.Execute("setXAttr", req, resp)
+}
+
+// GetUserAttrs - gets all the user namespace extended attributes, returned
+// value is in key value map string of string. Optionally you can provide
+// specific keys to get values from.
+func (c *Client) GetUserAttrs(name string, keys ...string) (map[string]string, error) {
+	req := &hdfs.GetXAttrsRequestProto{Src: proto.String(name)}
+	for _, key := range keys {
+		req.XAttrs = append(req.XAttrs, &hdfs.XAttrProto{
+			Namespace: hdfs.XAttrProto_USER.Enum(),
+			Name:      proto.String(key),
+		})
+	}
+	resp := &hdfs.GetXAttrsResponseProto{}
+
+	err := c.namenode.Execute("getXAttrs", req, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.GetXAttrs() == nil {
+		return nil, os.ErrNotExist
+	}
+
+	m := make(map[string]string)
+	for _, xattr := range resp.GetXAttrs() {
+		m[xattr.GetName()] = string(xattr.GetValue())
+
+	}
+	return m, nil
+}

--- a/xattr_test.go
+++ b/xattr_test.go
@@ -1,0 +1,28 @@
+package hdfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tj/assert"
+)
+
+func TestXAttrs(t *testing.T) {
+	client := getClient(t)
+
+	err := client.SetUserAttr("/_test/foo.txt", "key", "value")
+	require.NoError(t, err)
+
+	xattrs, err := client.ListUserAttrs("/_test/foo.txt")
+	require.NoError(t, err)
+
+	assert.EqualValues(t, xattrs["key"], "value")
+
+	err = client.RemoveUserAttr("/_test/foo.txt", "key")
+	require.NoError(t, err)
+
+	xattrs, err = client.ListUserAttrs("/_test/foo.txt")
+	require.NoError(t, err)
+
+	assert.EqualValues(t, len(xattrs), 0)
+}


### PR DESCRIPTION
The scope of this PR to only support user extended attributes,
setting other extended attributes such as in `trusted` namespace
is not useful without having system priviledges.

Fixes #178