### PR TITLE
implementing `ls -d` and `ls -R`

### DIFF
--- a/cmd/hdfs/main.go
+++ b/cmd/hdfs/main.go
@@ -43,6 +43,8 @@ Valid commands:
 	lsl    = lsOpts.Bool('l')
 	lsa    = lsOpts.Bool('a')
 	lsh    = lsOpts.Bool('h')
+	lsd    = lsOpts.Bool('d')
+	lsR    = lsOpts.Bool('R')
 
 	rmOpts = getopt.New()
 	rmr    = rmOpts.Bool('r')
@@ -107,7 +109,7 @@ func main() {
 		fatal("gohdfs version", version)
 	case "ls":
 		lsOpts.Parse(argv)
-		ls(lsOpts.Args(), *lsl, *lsa, *lsh)
+		ls(lsOpts.Args(), *lsl, *lsa, *lsh, *lsR, *lsd)
 	case "rm":
 		rmOpts.Parse(argv)
 		rm(rmOpts.Args(), *rmr, *rmf)

--- a/cmd/hdfs/test/ls.bats
+++ b/cmd/hdfs/test/ls.bats
@@ -39,6 +39,81 @@ stat /_test_cmd/nonexistent: file does not exist
 OUT
 }
 
+@test "ls -d" {
+  run $HDFS ls -d /_test_cmd/ls/dir1
+  assert_success
+  assert_output <<OUT
+/_test_cmd/ls/dir1
+OUT
+}
+
+@test "ls -d Wildcard" {
+  run $HDFS ls -d /_test_cmd/ls/dir*
+  assert_success
+  assert_output <<OUT
+/_test_cmd/ls/dir1
+/_test_cmd/ls/dir2
+/_test_cmd/ls/dir3
+OUT
+}
+
+@test "ls -ld" {
+  run $HDFS ls -ld /_test_cmd/ls
+  assert_success
+  regex="^drwxr-xr-x [a-z]+  hadoop  0 [a-zA-Z]+ [0-9]+ [0-9]{2}:[0-9]{2} /_test_cmd/ls$"
+  [[ $output =~ $regex ]]
+}
+
+@test "ls -ld Wildcard" {
+  run $HDFS ls -ld /_test_cmd/ls/dir*
+  assert_success
+  regex="^(drwxr-xr-x [a-z]+  hadoop  0 [a-zA-Z]+ [0-9]+ [0-9]{2}:[0-9]{2} /_test_cmd/ls/dir[1-3].{0,1}){3}$"
+  echo $output
+  [[ $output =~ $regex ]]
+}
+
+@test "ls -R root" {
+  run $HDFS ls -R /
+  assert_success
+}
+
+@test "ls -R dir" {
+  run $HDFS ls -R /_test_cmd/ls/
+  echo $output
+  assert_output <<OUT
+/_test_cmd/ls:
+total 3
+dir1
+dir2
+dir3
+
+/_test_cmd/ls/dir1:
+total 3
+a
+b
+c
+
+/_test_cmd/ls/dir2:
+total 1
+d
+
+/_test_cmd/ls/dir3:
+total 0
+OUT
+}
+
+@test "ls -R subdir" {
+  run $HDFS ls -R /_test_cmd/ls/dir1
+  echo $output
+  assert_output <<OUT
+/_test_cmd/ls/dir1:
+total 3
+a
+b
+c
+OUT
+}
+
 teardown() {
   $HDFS rm -r /_test_cmd/ls
 }


### PR DESCRIPTION
I've added two new features to ls: `-d` and `-R`

Their output behaviour is the same as that of the Unix tool.