### PR TITLE
Process AlreadyBeingCreatedException HDFS error as os.ErrExist on Create

### DIFF
--- a/error.go
+++ b/error.go
@@ -6,10 +6,11 @@ import (
 )
 
 const (
-	fileNotFoundException      = "java.io.FileNotFoundException"
-	permissionDeniedException  = "org.apache.hadoop.security.AccessControlException"
-	pathIsNotEmptyDirException = "org.apache.hadoop.fs.PathIsNotEmptyDirectoryException"
-	fileAlreadyExistsException = "org.apache.hadoop.fs.FileAlreadyExistsException"
+	fileNotFoundException        = "java.io.FileNotFoundException"
+	permissionDeniedException    = "org.apache.hadoop.security.AccessControlException"
+	pathIsNotEmptyDirException   = "org.apache.hadoop.fs.PathIsNotEmptyDirectoryException"
+	fileAlreadyExistsException   = "org.apache.hadoop.fs.FileAlreadyExistsException"
+	alreadyBeingCreatedException = "org.apache.hadoop.hdfs.protocol.AlreadyBeingCreatedException"
 )
 
 // Error represents a remote java exception from an HDFS namenode or datanode.
@@ -26,10 +27,14 @@ type Error interface {
 	Message() string
 }
 
-func interpretException(err error) error {
+func interpretExceptionWithExtraRules(err error, rules map[string]error) error {
 	var exception string
 	if remoteErr, ok := err.(Error); ok {
 		exception = remoteErr.Exception()
+	}
+
+	if ruleErr, ok := rules[exception]; ok {
+		return ruleErr
 	}
 
 	switch exception {
@@ -44,4 +49,8 @@ func interpretException(err error) error {
 	default:
 		return err
 	}
+}
+
+func interpretException(err error) error {
+	return interpretExceptionWithExtraRules(err, nil)
 }

--- a/file_writer.go
+++ b/file_writer.go
@@ -66,7 +66,8 @@ func (c *Client) CreateFile(name string, replication int, blockSize int64, perm 
 
 	err := c.namenode.Execute("create", createReq, createResp)
 	if err != nil {
-		return nil, &os.PathError{"create", name, interpretException(err)}
+		interpretedErr := interpretExceptionWithExtraRules(err, map[string]error{alreadyBeingCreatedException: os.ErrExist})
+		return nil, &os.PathError{"create", name, interpretedErr}
 	}
 
 	return &FileWriter{


### PR DESCRIPTION
Seems like there was a typo in HDFS exception name: the class name started with a small letter instead of a capital one (`org.apache.hadoop.fs.fileAlreadyExistsException` -> `org.apache.hadoop.fs.FileAlreadyExistsException`).

Also, if we try to create a file that already is being created, but is not closed yet, `org.apache.hadoop.hdfs.protocol.AlreadyBeingCreatedException` will occur (https://github.com/apache/hadoop/blob/a55d6bba71c81c1c4e9d8cd11f55c78f10a548b0/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/protocol/AlreadyBeingCreatedException.java#L32). Propose to convert this exception to `os.ErrExist` error too.