### PR TITLE
Fix building for plan9. Fixes #255

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,7 +2,6 @@ package hdfs
 
 import (
 	"os"
-	"syscall"
 )
 
 const (
@@ -38,7 +37,7 @@ func interpretException(err error) error {
 	case permissionDeniedException:
 		return os.ErrPermission
 	case pathIsNotEmptyDirException:
-		return syscall.ENOTEMPTY
+		return osErrNotEmpty
 	case fileAlreadyExistsException:
 		return os.ErrExist
 	default:

--- a/error_other.go
+++ b/error_other.go
@@ -1,0 +1,9 @@
+// +build !plan9
+
+package hdfs
+
+import (
+	"syscall"
+)
+
+var osErrNotEmpty = syscall.ENOTEMPTY

--- a/error_plan9.go
+++ b/error_plan9.go
@@ -1,0 +1,10 @@
+// +build plan9
+
+package hdfs
+
+import (
+	"errors"
+)
+
+// plan9 does not have ENOTEMPTY
+var osErrNotEmpty = errors.New(pathIsNotEmptyDirException)


### PR DESCRIPTION
This is a quick fix for the Plan9 build issue desribed in https://github.com/rclone/rclone/pull/4640#issuecomment-734450413

Reproduce by:
```
cd hdfs
GOOS=plan9 GOARCH=amd64 go build -o hdfs.plan9 -v ./cmd/hdfs
```

The issue prevents https://github.com/rclone/rclone from linking https://github.com/colinmarc/hdfs

This PR also fixes https://github.com/colinmarc/hdfs/issues/255
Please accept.
