### PR TITLE
Fix problems with SASL and Kerberos

### DIFF
--- a/internal/rpc/kerberos.go
+++ b/internal/rpc/kerberos.go
@@ -62,7 +62,7 @@ func (c *NamenodeConnection) doKerberosHandshake() error {
 			return err
 		}
 
-		qop := challenge.Qop[0]
+		qop := sasl.HighestQopLevel(challenge.Qop)
 		switch qop {
 		case sasl.QopPrivacy, sasl.QopIntegrity:
 			// Switch to SASL RPC handler

--- a/internal/sasl/challenge.go
+++ b/internal/sasl/challenge.go
@@ -65,3 +65,16 @@ func ParseChallenge(challenge []byte) (*Challenge, error) {
 
 	return &ch, nil
 }
+
+// HighestQopLevel extracts most secure Qop level from the list provided as an argument.
+func HighestQopLevel(qopList []string) string {
+	// Search provided list for most secure qop level.
+	for _, r := range []string{QopPrivacy, QopIntegrity, QopAuthentication} {
+		for _, qop := range qopList {
+			if qop == r {
+				return r
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Hello,

PR solves two problems we encountered when trying to use this tool to interact with our cluster. We have HortonWorks with Kerberos.
- The first problem was "unexpected sequence number" when trying to connect to NameNode. We have now solved it by selecting the highest possible QOP during SASL negotiation, but I cannot find a convincing explanation on the web that the highest should indeed be selected. It does not seem logical, whereas for some reason it works correctly.
- The second problem occurred when trying to upload a file, where we received an "unexpected EOF" error instead of success and an empty file on the cluster. Similarly, the file download failed. This behaviour is caused by improper SASL negotiation when connecting to a DataNode running on a privileged port. According to the https://hadoop.apache.org/docs/r3.1.0/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml documentation, the `dfs.data.transfer.protection` parameter should be ignored when DataNode is listening on privileged port, which should cause the connection negotiation process to not send a SASL Handshake. 
Here  is the link [to a code](https://github.com/apache/hadoop/blob/2b9a8c1d3a2caf1e733d57f346af3ff0d5ba529c/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/protocol/datatransfer/sasl/SaslDataTransferServer.java#L108) which i believe is used by HDFS server.

