### PR TITLE
Add a feature to sort QOP values for choosing highest priority

### DIFF
--- a/internal/rpc/kerberos.go
+++ b/internal/rpc/kerberos.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"sort"
 
 	hadoop "github.com/colinmarc/hdfs/v2/internal/protocol/hadoop_common"
 	"github.com/colinmarc/hdfs/v2/internal/sasl"
@@ -62,7 +63,12 @@ func (c *NamenodeConnection) doKerberosHandshake() error {
 			return err
 		}
 
+		// Sort the qops in order of level of encryption, highest to lowest.
+		// Some versions of HDP 3.x seem to break if we pick a Qop that isn't
+		// the highest (even if they sent it first in the list).
+		sort.Sort(challenge.Qop)
 		qop := challenge.Qop[0]
+
 		switch qop {
 		case sasl.QopPrivacy, sasl.QopIntegrity:
 			// Switch to SASL RPC handler

--- a/internal/sasl/challenge.go
+++ b/internal/sasl/challenge.go
@@ -20,12 +20,36 @@ const (
 	QopPrivacy = "auth-conf"
 )
 
+var qopPriority = map[string]int{
+	QopPrivacy:        2,
+	QopIntegrity:      1,
+	QopAuthentication: 0,
+}
+
+type Qops []string
+
+func (q Qops) Len() int { return len(q) }
+func (q Qops) Less(i, j int) bool {
+	p1, ok := qopPriority[q[i]]
+	if !ok {
+		p1 = -1
+	}
+
+	p2, ok := qopPriority[q[j]]
+	if !ok {
+		p2 = -1
+	}
+
+	return p1 > p2
+}
+func (q Qops) Swap(i, j int) { q[i], q[j] = q[j], q[i] }
+
 var challengeRegexp = regexp.MustCompile(",?([a-zA-Z0-9]+)=(\"([^\"]+)\"|([^,]+)),?")
 
 type Challenge struct {
 	Realm     string
 	Nonce     string
-	Qop       []string
+	Qop       Qops
 	Charset   string
 	Cipher    []string
 	Algorithm string

--- a/internal/sasl/challenge_test.go
+++ b/internal/sasl/challenge_test.go
@@ -1,0 +1,18 @@
+package sasl
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSortQops(t *testing.T) {
+	allQops := Qops{QopAuthentication, QopIntegrity, QopPrivacy}
+	sort.Sort(allQops)
+	assert.Equal(t, Qops{QopPrivacy, QopIntegrity, QopAuthentication}, allQops)
+
+	includeInvalidQops := Qops{QopAuthentication, QopPrivacy, "invalid"}
+	sort.Sort(includeInvalidQops)
+	assert.Equal(t, Qops{QopPrivacy, QopAuthentication, "invalid"}, includeInvalidQops)
+}


### PR DESCRIPTION
Hi, This pr is quite similar to this https://github.com/colinmarc/hdfs/pull/260, but I uploaded a new one since the author of the previous PR has no feedback yet.

The main reason that I added this feature is the same reason from the previous PR description.
> The first problem was "unexpected sequence number" when trying to connect to NameNode. We have now solved it by selecting the highest possible QOP during SASL negotiation, but I cannot find a convincing explanation on the web that the highest should indeed be selected. It does not seem logical, whereas for some reason it works correctly.

Since we need this PR to be merged ASAP, I'll reply as quickly as possible. Thanks.