### PR TITLE
Fix bug of closing file

### DIFF
--- a/file_writer.go
+++ b/file_writer.go
@@ -1,6 +1,7 @@
 package hdfs
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -239,6 +240,9 @@ func (f *FileWriter) Close() error {
 	err := f.client.namenode.Execute("complete", completeReq, completeResp)
 	if err != nil {
 		return &os.PathError{"create", f.name, err}
+	}
+	if !completeResp.GetResult() {
+		return fmt.Errorf("failed to close file %s, the Result of CompleteResponseProto is false", f.name)
 	}
 
 	return nil


### PR DESCRIPTION
Fix bug of closing file.

Sometimes although the Close() method returns success, but the remote file is not really closed. Because the Result of CompleteResponseProto is not checked here. 