### PR TITLE
Allow to use multiple nodes in HADOOP_NAMENODE

### DIFF
--- a/cmd/hdfs/main.go
+++ b/cmd/hdfs/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/user"
+	"strings"
 	"time"
 
 	"github.com/colinmarc/hdfs/v2"
@@ -189,7 +190,7 @@ func getClient(namenode string) (*hdfs.Client, error) {
 
 	options := hdfs.ClientOptionsFromConf(conf)
 	if namenode != "" {
-		options.Addresses = []string{namenode}
+		options.Addresses = strings.Split(namenode, ",")
 	}
 
 	if options.Addresses == nil {


### PR DESCRIPTION
First of all, I'm happy to use your awesome library. 
But there was impossible to pass multiple nodes addresses in cli mode like this way:
```
HADOOP_NAMENODE="spark01.lan:8020,spark02.lan:8020" HADOOP_USER_NAME=dev go run ./cmd/hdfs ls /user/airflow/
```

