### PR TITLE
Allow to set only one of mtime/atime file attribute at a time

### DIFF
--- a/perms.go
+++ b/perms.go
@@ -47,10 +47,28 @@ func (c *Client) Chown(name string, user, group string) error {
 
 // Chtimes changes the access and modification times of the named file.
 func (c *Client) Chtimes(name string, atime time.Time, mtime time.Time) error {
+
+	var protoAtime *uint64
+	var protoMtime *uint64
+
+	// Treat empty atime/mtime time objects as "no need to set time" flag
+	// Doc: https://hadoop.apache.org/docs/stable/api/org/apache/hadoop/fs/FileSystem.html#setTimes-org.apache.hadoop.fs.Path-long-long-
+	if (time.Time{}) == atime {
+		protoAtime = proto.Uint64(uint64(-1))
+	} else {
+		protoAtime = proto.Uint64(uint64(atime.Unix()) * 1000)
+	}
+
+	if (time.Time{}) == mtime {
+		protoMtime = proto.Uint64(uint64(-1))
+	} else {
+		protoMtime = proto.Uint64(uint64(mtime.Unix()) * 1000)
+	}
+
 	req := &hdfs.SetTimesRequestProto{
 		Src:   proto.String(name),
-		Mtime: proto.Uint64(uint64(mtime.Unix()) * 1000),
-		Atime: proto.Uint64(uint64(atime.Unix()) * 1000),
+		Mtime: protoMtime,
+		Atime: protoAtime,
 	}
 	resp := &hdfs.SetTimesResponseProto{}
 

--- a/perms_test.go
+++ b/perms_test.go
@@ -111,4 +111,25 @@ func TestChtimes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, birthday, fi.ModTime().UTC(), birthday)
 	assert.EqualValues(t, birthday, fi.(*FileInfo).AccessTime().UTC(), birthday)
+
+
+        // Test if "no need to set time flag (empty time.Time{})" works fine
+	birthdayRetouch := time.Date(1991, 1, 22, 14, 33, 35, 0, time.UTC)
+
+        // Change atime, keep mtime
+	client.Chtimes("/_test/tochtime", birthdayRetouch, time.Time{})
+	fiAtime, err := client.Stat("/_test/tochtime")
+	assert.NoError(t, err)
+	assert.EqualValues(t, birthday, fiAtime.ModTime().UTC(), birthday)
+	assert.EqualValues(t, birthdayRetouch, fiAtime.(*FileInfo).AccessTime().UTC(), birthdayRetouch)
+
+        // Reset
+	client.Chtimes("/_test/tochtime", birthday, birthday)
+
+        // Keep atime, change mtime
+	client.Chtimes("/_test/tochtime", time.Time{}, birthdayRetouch)
+	fiMtime, err := client.Stat("/_test/tochtime")
+	assert.NoError(t, err)
+	assert.EqualValues(t, birthdayRetouch, fiMtime.ModTime().UTC(), birthdayRetouch)
+	assert.EqualValues(t, birthday, fiMtime.(*FileInfo).AccessTime().UTC(), birthday)
 }


### PR DESCRIPTION
Java methods allow to set only one of atime/mtime attribute: https://hadoop.apache.org/docs/stable/api/org/apache/hadoop/fs/FileSystem.html#setTimes-org.apache.hadoop.fs.Path-long-long-

Just trying to implement it here.