### PR TITLE
Change default checksum type to CRC32C

### DIFF
--- a/internal/protocol/hadoop_hdfs/hdfs.pb.go
+++ b/internal/protocol/hadoop_hdfs/hdfs.pb.go
@@ -3609,7 +3609,7 @@ type FsServerDefaultsProto struct {
 const (
 	Default_FsServerDefaultsProto_EncryptDataTransfer = bool(false)
 	Default_FsServerDefaultsProto_TrashInterval       = uint64(0)
-	Default_FsServerDefaultsProto_ChecksumType        = ChecksumTypeProto_CHECKSUM_CRC32
+	Default_FsServerDefaultsProto_ChecksumType        = ChecksumTypeProto_CHECKSUM_CRC32C
 	Default_FsServerDefaultsProto_PolicyId            = uint32(0)
 )
 

--- a/internal/protocol/hadoop_hdfs/hdfs.proto
+++ b/internal/protocol/hadoop_hdfs/hdfs.proto
@@ -524,7 +524,7 @@ message FsServerDefaultsProto {
   required uint32 fileBufferSize = 5;
   optional bool encryptDataTransfer = 6 [default = false];
   optional uint64 trashInterval = 7 [default = 0];
-  optional ChecksumTypeProto checksumType = 8 [default = CHECKSUM_CRC32];
+  optional ChecksumTypeProto checksumType = 8 [default = CHECKSUM_CRC32C];
   optional string keyProviderUri = 9;
   optional uint32 policyId = 10 [default = 0];
 }

--- a/internal/transfer/block_writer.go
+++ b/internal/transfer/block_writer.go
@@ -218,7 +218,7 @@ func (bw *BlockWriter) writeBlockWriteRequest(w io.Writer) error {
 		MaxBytesRcvd:          proto.Uint64(uint64(bw.Offset)),
 		LatestGenerationStamp: proto.Uint64(uint64(bw.generationTimestamp())),
 		RequestedChecksum: &hdfs.ChecksumProto{
-			Type:             hdfs.ChecksumTypeProto_CHECKSUM_CRC32.Enum(),
+			Type:             hdfs.ChecksumTypeProto_CHECKSUM_CRC32C.Enum(),
 			BytesPerChecksum: proto.Uint32(outboundChunkSize),
 		},
 	}


### PR DESCRIPTION
Changing the default checksum type to CRC32.

We have some users using uploading files which has the checksum type of "CRC32", but the default type is "CRC32C" since the very begining. 

This will cause a checksum mismatch issue when users are using distcp to copy the files. Although we can work around this issue on HDFS side by adding "-pc" to the distcp command, we think it's also good to change the default value from GO side.