### PR TITLE
fix: return actual validated bytes on checksum mismatch

### DIFF
--- a/internal/transfer/block_read_stream.go
+++ b/internal/transfer/block_read_stream.go
@@ -109,7 +109,7 @@ func (s *blockReadStream) Read(b []byte) (int, error) {
 
 		err := s.validateChecksum(b[chunkOff:chunkEnd])
 		if err != nil {
-			return n, err
+			return chunkOff, err
 		}
 
 		s.chunkIndex++


### PR DESCRIPTION
When a checksum validation fails, the current code returns the total number of bytes read (n) even though some of those bytes have not been verified. This PR changes the error path to return the offset of the first invalid chunk (chunkOff) instead.

-  Guarantees that only successfully-verified data is ever returned to the caller.
- Triggers an immediate failover to the next DataNode on the next Read call.

The change is minimal and preserves all existing retry / failover semantics.